### PR TITLE
Add -L flag to curl command to follow redirects in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -166,7 +166,7 @@ function check_dependency_and_install() {
 
 # If version was not given it will install the latest version
 if [[ "${VERSION}" == "latest" ]]; then
-  LATEST_VERSION=$(curl -s https://api.github.com/repos/runtipi/runtipi/releases/latest | grep tag_name | cut -d '"' -f4)
+  LATEST_VERSION=$(curl -sL https://api.github.com/repos/runtipi/runtipi/releases/latest | grep tag_name | cut -d '"' -f4)
   VERSION="${LATEST_VERSION}"
 fi
 


### PR DESCRIPTION
The previous curl command in install.sh was failing due to a permanent redirect on the GitHub API endpoint. This error was manifesting as a "Moved Permanently" message when attempting to fetch the latest release version. By adding the -L flag to the curl command, the script now correctly follows the redirect to the new URL, ensuring the latest version information is accurately retrieved. This change resolves the error and ensures the installation script operates reliably.