### PR TITLE
feat(cli): add commands for starting and stopping apps

### DIFF
--- a/packages/cli/src/executors/app/app.executors.ts
+++ b/packages/cli/src/executors/app/app.executors.ts
@@ -152,10 +152,10 @@ export class AppExecutors {
     try {
       this.logger.info(`Stopping app ${appId}`);
 
-      this.logger.info(`Regenerating app.env file for app ${appId}`);
       await this.ensureAppDir(appId);
 
       if (!skipEnvGeneration) {
+        this.logger.info(`Regenerating app.env file for app ${appId}`);
         await generateEnvFile(appId, config);
       }
       await compose(appId, 'rm --force --stop');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { program } from 'commander';
 import chalk from 'chalk';
 import { description, version } from '../package.json';
 import { startWorker } from './services/watcher/watcher';
-import { SystemExecutors } from './executors';
+import { AppExecutors, SystemExecutors } from './executors';
 
 const main = async () => {
   program.description(description).version(version);
@@ -67,6 +67,25 @@ const main = async () => {
     .action(async () => {
       const systemExecutors = new SystemExecutors();
       await systemExecutors.cleanLogs();
+    });
+
+  // Start app: ./cli app start <app>
+  // Stop app: ./cli app stop <app>
+  program
+    .command('app [command] <app>')
+    .description('App management')
+    .action(async (command, app) => {
+      const appExecutors = new AppExecutors();
+      switch (command) {
+        case 'start':
+          await appExecutors.startApp(app, {});
+          break;
+        case 'stop':
+          await appExecutors.stopApp(app, {}, true);
+          break;
+        default:
+          console.log(chalk.red('✗'), 'Unknown command');
+      }
     });
 
   program.parse(process.argv);


### PR DESCRIPTION
## Purpose
In order to perform maintenance with apps. The commands `stop` and `start` have been added to the runtipi cli.

## Example
- `./runtipi-cli app start nextcloud`
- `./runtipi-cli app stop nextcloud`