### PR TITLE
chore(cli): generate APP_PROTOCOL env var even for http

### DIFF
--- a/packages/cli/src/executors/app/app.helpers.ts
+++ b/packages/cli/src/executors/app/app.helpers.ts
@@ -97,6 +97,7 @@ export const generateEnvFile = async (appId: string, config: Record<string, unkn
   } else {
     envMap.set('APP_DOMAIN', `${internalIp}:${parsedConfig.data.port}`);
     envMap.set('APP_HOST', internalIp);
+    envMap.set('APP_PROTOCOL', 'http');
   }
 
   // Create app-data folder if it doesn't exist


### PR DESCRIPTION
## Purpose
During app.env generation, `APP_PROTOCOL` is generated only if the protocol is https. Some apps require the use of this variable in templates thus requiring a value when http