### PR TITLE
fix(app-store): show a text when there is no filtering result

### DIFF
--- a/src/app/(dashboard)/app-store/components/AppStoreTable/AppStoreTable.tsx
+++ b/src/app/(dashboard)/app-store/components/AppStoreTable/AppStoreTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { EmptyPage } from '../../../../components/EmptyPage';
 import { AppStoreTile } from '../AppStoreTile';
 import { AppTableData } from '../../helpers/table.types';
 import { useAppStoreState } from '../../state/appStoreState';
@@ -15,11 +16,17 @@ export const AppStoreTable: React.FC<IProps> = ({ data }) => {
 
   const tableData = React.useMemo(() => sortTable({ data: data || [], col: sort, direction: sortDirection, category, search }), [data, sort, sortDirection, category, search]);
 
+  if (!tableData.length) {
+    return <EmptyPage title="apps.app-store.no-results" subtitle="apps.app-store.no-results-subtitle" />;
+  }
+
   return (
-    <div className="row row-cards">
-      {tableData.map((app) => (
-        <AppStoreTile key={app.id} app={app} />
-      ))}
+    <div className="card px-3 pb-3">
+      <div className="row row-cards">
+        {tableData.map((app) => (
+          <AppStoreTile key={app.id} app={app} />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/app/(dashboard)/app-store/page.tsx
+++ b/src/app/(dashboard)/app-store/page.tsx
@@ -15,9 +15,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function AppStorePage() {
   const { apps } = await AppServiceClass.listApps();
 
-  return (
-    <div className="card px-3 pb-3">
-      <AppStoreTable data={apps} />
-    </div>
-  );
+  return <AppStoreTable data={apps} />;
 }


### PR DESCRIPTION
## Purpose
Missing empty page text when filtering app-store close #795