### PR TITLE
Make install form scrollable

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@otplib/plugin-thirty-two": "^12.0.1",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.6
         version: 2.0.6(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.0.5
+        version: 1.0.5(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-select':
         specifier: ^2.0.0
         version: 2.0.0(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
@@ -2528,6 +2531,35 @@ packages:
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.31)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@types/react': 18.2.31
+      '@types/react-dom': 18.2.14
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-scroll-area@1.0.5(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.31)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.31)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.31)(react@18.2.0)
       '@types/react': 18.2.31
       '@types/react-dom': 18.2.14
       react: 18.2.0

--- a/src/app/(dashboard)/app-store/[id]/components/InstallModal/InstallModal.tsx
+++ b/src/app/(dashboard)/app-store/[id]/components/InstallModal/InstallModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader } from '@/components/ui/Dialog';
 import { useTranslations } from 'next-intl';
 import { AppInfo } from '@runtipi/shared';
+import { ScrollArea } from '@/components/ui/ScrollArea';
 import { InstallForm, FormValues } from '../InstallForm';
 
 interface IProps {
@@ -20,9 +21,11 @@ export const InstallModal: React.FC<IProps> = ({ info, isOpen, onClose, onSubmit
         <DialogHeader>
           <h5 className="modal-title">{t('title', { name: info.name })}</h5>
         </DialogHeader>
-        <DialogDescription>
-          <InstallForm onSubmit={onSubmit} formFields={info.form_fields} info={info} />
-        </DialogDescription>
+        <ScrollArea maxHeight={500}>
+          <DialogDescription>
+            <InstallForm onSubmit={onSubmit} formFields={info.form_fields} info={info} />
+          </DialogDescription>
+        </ScrollArea>
       </DialogContent>
     </Dialog>
   );

--- a/src/app/(dashboard)/app-store/[id]/components/UpdateSettingsModal/UpdateSettingsModal.tsx
+++ b/src/app/(dashboard)/app-store/[id]/components/UpdateSettingsModal/UpdateSettingsModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader } from '@/components/ui/Dialog';
 import { useTranslations } from 'next-intl';
 import { AppInfo } from '@runtipi/shared';
+import { ScrollArea } from '@/components/ui/ScrollArea';
 import { InstallForm, type FormValues } from '../InstallForm';
 
 interface IProps {
@@ -23,9 +24,11 @@ export const UpdateSettingsModal: React.FC<IProps> = ({ info, config, isOpen, on
         <DialogHeader>
           <h5 className="modal-title">{t('title', { name: info.name })}</h5>
         </DialogHeader>
-        <DialogDescription>
-          <InstallForm onSubmit={onSubmit} formFields={info.form_fields} info={info} initalValues={{ ...config, exposed, domain }} />
-        </DialogDescription>
+        <ScrollArea maxHeight={500}>
+          <DialogDescription>
+            <InstallForm onSubmit={onSubmit} formFields={info.form_fields} info={info} initalValues={{ ...config, exposed, domain }} />
+          </DialogDescription>
+        </ScrollArea>
       </DialogContent>
     </Dialog>
   );

--- a/src/client/components/ui/ScrollArea/ScrollArea.module.css
+++ b/src/client/components/ui/ScrollArea/ScrollArea.module.css
@@ -1,0 +1,26 @@
+.viewport {
+  height: 100%;
+  width: 100%;
+  border-radius: inherit;
+}
+
+.scrollbar {
+  display: flex;
+  touch-action: none;
+  user-select: none;
+  transition: color 0.3s ease;
+}
+
+.scrollbarVertical {
+  height: 100%;
+  width: 0.625rem;
+  border-left: 1px solid transparent;
+  padding: 0 1px;
+}
+
+.scrollbarHorizontal {
+  flex-direction: column;
+  height: 0.625rem;
+  border-top: 1px solid transparent;
+  padding: 0 1px;
+}

--- a/src/client/components/ui/ScrollArea/ScrollArea.tsx
+++ b/src/client/components/ui/ScrollArea/ScrollArea.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import * as React from 'react';
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+import clsx from 'clsx';
+import styles from './ScrollArea.module.css';
+
+const ScrollBar = React.forwardRef<React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>, React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>>(
+  ({ className, orientation = 'vertical', ...props }, ref) => (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      ref={ref}
+      orientation={orientation}
+      className={clsx(styles.scrollbar, { [styles.scrollbarVertical!]: orientation === 'vertical', [styles.scrollbarHorizontal!]: orientation === 'horizontal' }, className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb className={clsx('position-relative rounded-pill bg-muted', orientation === 'vertical' && 'flex-grow-1')} />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  ),
+);
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+const ScrollArea = React.forwardRef<React.ElementRef<typeof ScrollAreaPrimitive.Root>, React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & { maxHeight: number }>(
+  ({ className, children, ...props }, ref) => (
+    <ScrollAreaPrimitive.Root ref={ref} className={clsx('position-relative overflow-hidden', className)} {...props}>
+      <ScrollAreaPrimitive.Viewport style={{ maxHeight: props.maxHeight }} className={clsx(styles.viewport, 'w-100')}>
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  ),
+);
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/src/client/components/ui/ScrollArea/index.ts
+++ b/src/client/components/ui/ScrollArea/index.ts
@@ -1,0 +1,1 @@
+export { ScrollArea } from './ScrollArea';


### PR DESCRIPTION
## Purpose
Sometimes if the app has many field required to be filled by the user, the install form would go off screen and making it hard for the user to reach the end. This PR adds a new `ScrollArea` component based on radix-ui's primitive. The height of the modal content will be capped at 500px and be scrollable after that.

![Screenshot 2023-10-26 at 08 50 46](https://github.com/runtipi/runtipi/assets/47644445/ccab3e2b-6e1d-4531-ba87-4cd6ec0b957d)

Closes #770