### PR TITLE
feat(cli): set custom postgres port in config.json

### DIFF
--- a/packages/cli/assets/docker-compose.yml
+++ b/packages/cli/assets/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     restart: on-failure
     stop_grace_period: 1m
     ports:
-      - 5432:5432
+      - ${POSTGRES_PORT}:5432
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
     environment:

--- a/packages/cli/assets/docker-compose.yml
+++ b/packages/cli/assets/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     restart: on-failure
     stop_grace_period: 1m
     ports:
-      - ${POSTGRES_PORT}:5432
+      - ${POSTGRES_PORT-5432}:5432
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
     environment:

--- a/packages/cli/src/executors/system/system.helpers.ts
+++ b/packages/cli/src/executors/system/system.helpers.ts
@@ -175,7 +175,7 @@ export const generateSystemEnvFile = async () => {
   envMap.set('POSTGRES_DBNAME', 'tipi');
   envMap.set('POSTGRES_USERNAME', 'tipi');
   envMap.set('POSTGRES_PASSWORD', postgresPassword);
-  envMap.set('POSTGRES_PORT', String(data.posgresPort || 5432));
+  envMap.set('POSTGRES_PORT', String(data.postgresPort || 5432));
   envMap.set('REDIS_HOST', 'tipi-redis');
   envMap.set('REDIS_PASSWORD', redisPassword);
   envMap.set('DEMO_MODE', String(data.demoMode || 'false'));

--- a/packages/cli/src/executors/system/system.helpers.ts
+++ b/packages/cli/src/executors/system/system.helpers.ts
@@ -175,7 +175,7 @@ export const generateSystemEnvFile = async () => {
   envMap.set('POSTGRES_DBNAME', 'tipi');
   envMap.set('POSTGRES_USERNAME', 'tipi');
   envMap.set('POSTGRES_PASSWORD', postgresPassword);
-  envMap.set('POSTGRES_PORT', String(data.posgresPassword || 5432));
+  envMap.set('POSTGRES_PORT', String(data.posgresPort || 5432));
   envMap.set('REDIS_HOST', 'tipi-redis');
   envMap.set('REDIS_PASSWORD', redisPassword);
   envMap.set('DEMO_MODE', String(data.demoMode || 'false'));

--- a/packages/cli/src/executors/system/system.helpers.ts
+++ b/packages/cli/src/executors/system/system.helpers.ts
@@ -175,7 +175,7 @@ export const generateSystemEnvFile = async () => {
   envMap.set('POSTGRES_DBNAME', 'tipi');
   envMap.set('POSTGRES_USERNAME', 'tipi');
   envMap.set('POSTGRES_PASSWORD', postgresPassword);
-  envMap.set('POSTGRES_PORT', String(5432));
+  envMap.set('POSTGRES_PORT', String(data.posgresPassword || 5432));
   envMap.set('REDIS_HOST', 'tipi-redis');
   envMap.set('REDIS_PASSWORD', redisPassword);
   envMap.set('DEMO_MODE', String(data.demoMode || 'false'));

--- a/packages/shared/src/schemas/env-schemas.ts
+++ b/packages/shared/src/schemas/env-schemas.ts
@@ -64,4 +64,4 @@ export const envSchema = z.object({
 export const settingsSchema = envSchema
   .partial()
   .pick({ dnsIp: true, internalIp: true, appsRepoUrl: true, domain: true, storagePath: true, localDomain: true, demoMode: true, guestDashboard: true })
-  .and(z.object({ port: z.number(), sslPort: z.number(), listenIp: z.string().ip().trim() }).partial());
+  .and(z.object({ port: z.number(), sslPort: z.number(), postgresPort: z.number(), listenIp: z.string().ip().trim() }).partial());

--- a/packages/shared/src/schemas/env-schemas.ts
+++ b/packages/shared/src/schemas/env-schemas.ts
@@ -63,5 +63,5 @@ export const envSchema = z.object({
 
 export const settingsSchema = envSchema
   .partial()
-  .pick({ dnsIp: true, internalIp: true, appsRepoUrl: true, domain: true, storagePath: true, localDomain: true, demoMode: true, guestDashboard: true })
-  .and(z.object({ port: z.number(), sslPort: z.number(), postgresPort: z.number(), listenIp: z.string().ip().trim() }).partial());
+  .pick({ dnsIp: true, internalIp: true, postgresPort: true, appsRepoUrl: true, domain: true, storagePath: true, localDomain: true, demoMode: true, guestDashboard: true })
+  .and(z.object({ port: z.number(), sslPort: z.number(), listenIp: z.string().ip().trim() }).partial());


### PR DESCRIPTION
Update the cli part to be able to take an extra config option: ```postgresPort``` for changing the port that postgres will listen to. Issue here: https://github.com/runtipi/runtipi/issues/897