### PR TITLE
refactor: download docker compose binary

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,6 @@ services:
       context: .
       dockerfile: ./packages/worker/Dockerfile
     container_name: tipi-worker
-    user: root
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:3000/healthcheck']
       interval: 5s

--- a/packages/cli/assets/docker-compose.yml
+++ b/packages/cli/assets/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   tipi-reverse-proxy:
     container_name: tipi-reverse-proxy
     image: traefik:v2.8
-    restart: on-failure
+    restart: unless-stopped
     depends_on:
       - tipi-dashboard
     ports:
@@ -42,7 +42,7 @@ services:
   tipi-redis:
     container_name: tipi-redis
     image: redis:7.2.0
-    restart: on-failure
+    restart: unless-stopped
     command: redis-server --requirepass ${REDIS_PASSWORD}
     ports:
       - 6379:6379
@@ -59,6 +59,7 @@ services:
   tipi-worker:
     container_name: tipi-worker
     image: ghcr.io/runtipi/worker:${TIPI_VERSION}
+    restart: unless-stopped
     user: root
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:3000/healthcheck']
@@ -95,7 +96,7 @@ services:
 
   tipi-dashboard:
     image: ghcr.io/runtipi/runtipi:${TIPI_VERSION}
-    restart: on-failure
+    restart: unless-stopped
     container_name: tipi-dashboard
     networks:
       - tipi_main_network

--- a/packages/worker/Dockerfile
+++ b/packages/worker/Dockerfile
@@ -3,20 +3,38 @@ ARG ALPINE_VERSION="3.18"
 
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS node_base
 
+# ---- BUILDER BASE ----
 FROM node_base AS builder_base
 
 RUN npm install pnpm -g
+RUN apk add curl
 
+# ---- RUNNER BASE ----
 FROM node_base AS runner_base
 
-# Install docker
-RUN apk upgrade --update-cache --available && \
-  apk add openssl git docker docker-cli-compose curl && \
-  rm -rf /var/cache/apk/*
+RUN apk add curl openssl git && rm -rf /var/cache/apk/*
 
+ARG NODE_ENV="production"
+
+# ---- BUILDER ----
 FROM builder_base AS builder
 
 WORKDIR /app
+
+ARG TARGETARCH
+ENV TARGETARCH=${TARGETARCH}
+
+RUN echo "Building for ${TARGETARCH}"
+
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-aarch64"; \
+  elif [ "${TARGETARCH}" = "amd64" ]; then \
+  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-x86_64"; \
+  else \
+  echo "Unsupported architecture"; \
+  fi
+
+RUN chmod +x docker-binary
 
 COPY ./pnpm-lock.yaml ./
 COPY ./pnpm-workspace.yaml ./
@@ -34,6 +52,7 @@ COPY ./packages/worker/assets ./packages/worker/assets
 
 RUN pnpm -r build --filter @runtipi/worker
 
+# ---- RUNNER ----
 FROM runner_base AS app
 
 WORKDIR /app
@@ -42,6 +61,7 @@ ENV NODE_ENV=production
 
 COPY --from=builder /app/packages/worker/dist .
 COPY --from=builder /app/packages/worker/assets ./assets
+COPY --from=builder /app/docker-binary /usr/local/bin/docker-compose
 
 CMD ["node", "index.js", "start"]
 

--- a/packages/worker/Dockerfile.dev
+++ b/packages/worker/Dockerfile.dev
@@ -5,8 +5,23 @@ FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS node_base
 
 # Install docker
 RUN apk upgrade --update-cache --available && \
-  apk add openssl git docker docker-cli-compose curl unzip && \
+  apk add openssl git docker docker-cli-compose curl && \
   rm -rf /var/cache/apk/*
+
+ARG TARGETARCH
+ENV TARGETARCH=${TARGETARCH}
+
+RUN echo "Building for ${TARGETARCH}"
+
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-aarch64"; \
+  elif [ "${TARGETARCH}" = "amd64" ]; then \
+  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-x86_64"; \
+  fi
+
+RUN chmod +x docker-binary
+
+RUN mv docker-binary /usr/local/bin/docker-compose
 
 RUN npm install pnpm -g
 

--- a/packages/worker/src/lib/docker/docker-helpers.test.ts
+++ b/packages/worker/src/lib/docker/docker-helpers.test.ts
@@ -34,7 +34,7 @@ describe('docker helpers', async () => {
 
     // assert
     const expected = [
-      'docker compose',
+      'docker-compose',
       `--env-file /storage/app-data/${appId}/app.env`,
       `--project-name ${appId}`,
       `-f /app/apps/${appId}/docker-compose.yml`,
@@ -58,7 +58,7 @@ describe('docker helpers', async () => {
 
     // assert
     const expected = [
-      'docker compose',
+      'docker-compose',
       `--env-file /storage/app-data/${appId}/app.env`,
       `--env-file ${userEnvFile}`,
       `--project-name ${appId}`,
@@ -83,7 +83,7 @@ describe('docker helpers', async () => {
 
     // assert
     const expected = [
-      'docker compose',
+      'docker-compose',
       `--env-file /storage/app-data/${appId}/app.env`,
       `--project-name ${appId}`,
       `-f /app/apps/${appId}/docker-compose.yml`,
@@ -112,7 +112,7 @@ describe('docker helpers', async () => {
 
     // assert
     const expected = [
-      'docker compose',
+      'docker-compose',
       `--env-file /storage/app-data/${appId}/app.env`,
       `--project-name ${appId}`,
       `-f ${arm64ComposeFile}`,

--- a/packages/worker/src/lib/docker/docker-helpers.ts
+++ b/packages/worker/src/lib/docker/docker-helpers.ts
@@ -6,7 +6,7 @@ import { ROOT_FOLDER, STORAGE_FOLDER } from '@/config/constants';
 
 const composeUp = async (args: string[]) => {
   logger.info(`Running docker compose with args ${args.join(' ')}`);
-  const { stdout, stderr } = await execAsync(`docker compose ${args.join(' ')}`);
+  const { stdout, stderr } = await execAsync(`docker-compose ${args.join(' ')}`);
 
   if (stderr && stderr.includes('Command failed:')) {
     throw new Error(stderr);


### PR DESCRIPTION
## Purpose
In an attempt to reduce the size of the worker image, it was discovered that downloading the docker cli binary directly instead of adding it through the package manager resulted in a half-size image. Thank you @steveiliop56 for your precious help on this one