### PR TITLE
fix(app-update): change update confirmation text

### DIFF
--- a/src/client/messages/en.json
+++ b/src/client/messages/en.json
@@ -220,7 +220,7 @@
       "update-form": {
         "title": "Update {name} ?",
         "subtitle1": "Update app to latest verion :",
-        "subtitle2": "This will reset your custom configuration (e.g. changes in docker-compose.yml)",
+        "subtitle2": "Make sure you've read the release notes of the app and you've backed up your app data.",
         "submit": "Update"
       },
       "update-settings-form": {


### PR DESCRIPTION
The current update prompt is not accurate anymore. So migrating to a simpler info that is easier to understand.