### PR TITLE
fix(worker): display disk usage right

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -76,7 +76,7 @@ services:
     environment:
       NODE_ENV: production
     volumes:
-      - /:/host/root:ro
+      - /:/mnt/host:ro
       - /proc:/host/proc
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}/.env:/app/.env

--- a/packages/cli/assets/docker-compose.yml
+++ b/packages/cli/assets/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       NODE_ENV: production
     volumes:
       # Core
-      - /:/host/root:ro
+      - /:/mnt/host:ro
       - /proc:/host/proc
       - /var/run/docker.sock:/var/run/docker.sock
       # App

--- a/packages/worker/src/services/system/system.executors.ts
+++ b/packages/worker/src/services/system/system.executors.ts
@@ -37,7 +37,7 @@ export class SystemExecutors {
     }
 
     const disks = await si.fsSize();
-    const disk0 = disks.find((disk) => disk.mount.startsWith('/mnt/host') && disk.type === 'fakeowner');
+    const disk0 = disks.find((disk) => disk.mount.startsWith('/mnt/host'));
 
     return {
       cpu: { load: currentLoad },


### PR DESCRIPTION
The disk.type function was not used right resulting in the disk usage not being displayed. Since the /mnt/host inside the container will always be ext4 we can skip the disk type function completely. Moreover in the docker-compose.prod.yml file the mount was not set right resulting in an error in the production environment.