### PR TITLE
feat(support-repoURL-with-branch-syntax): If a appstore repo URL contains a branch, checkout that branch

### DIFF
--- a/packages/worker/src/services/repo/repo.helpers.ts
+++ b/packages/worker/src/services/repo/repo.helpers.ts
@@ -10,3 +10,18 @@ export const getRepoHash = (repoUrl: string) => {
   hash.update(repoUrl);
   return hash.digest('hex');
 };
+
+
+/**
+ * Extracts the base URL and branch from a repository URL.
+ * @param repoUrl The repository URL.
+ * @returns An array containing the base URL and branch, or just the base URL if no branch is found.
+ */
+export const getRepoBaseUrlAndBranch = (repoUrl: string) => {
+  const branchMatch = repoUrl.match(/^(.*)\/tree\/(.*)$/);
+  if (branchMatch) {
+    return [branchMatch[1], branchMatch[2]] ;
+  }
+
+  return [repoUrl, undefined] ;
+};


### PR DESCRIPTION
### Why
This pull request addresses a limitation with runtipi [Application Repository](https://runtipi.io/docs/apps-available) custom repo URLs as it is restricted to using only the master branch. This restriction forced developers of new apps definition to either manually update the repository branch on the runtipi server filesystem or [merge unfinished work into their main branch](https://giphy.com/clips/theoffice-lkibHaGO1xmJXapEdq).


### What
This pull request addresses this by allowing people to specify an optional branch along with the Git repository URL, enabling them to work on projects without affecting their main branch. 
We can now use the following syntax:
- https://github.com/foobar/runtipi-appstore
- https://github.com/foobar/runtipi-appstore/tree/renovate/n8nio-n8n-1.x

The code modifications are straightforward and can be found in the packages/worker/src/services/repo helpers.

### Additional notes
* I'll make a PR to the documentation website to reflect this change
* It's worth noticing that after modifying the URL through /settings?tab=settings, I had to restart twice `npm run start:dev` to make the new values visible web pages, while I was expecting something at the very next one. 🤷 
