### PR TITLE
fix(worker): remount / to /host/root

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -80,6 +80,7 @@ services:
       # Dev mode
       - ${PWD}/packages/worker/src:/app/packages/worker/src
       # Production mode
+      - /:/host/root:ro
       - /proc:/host/proc:ro
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}/.env:/app/.env

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -76,6 +76,7 @@ services:
     environment:
       NODE_ENV: production
     volumes:
+      - /:/host/root:ro
       - /proc:/host/proc
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}/.env:/app/.env

--- a/packages/cli/assets/docker-compose.yml
+++ b/packages/cli/assets/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       NODE_ENV: production
     volumes:
       # Core
+      - /:/host/root:ro
       - /proc:/host/proc
       - /var/run/docker.sock:/var/run/docker.sock
       # App

--- a/packages/worker/src/services/system/system.executors.ts
+++ b/packages/worker/src/services/system/system.executors.ts
@@ -36,7 +36,8 @@ export class SystemExecutors {
       this.logger.error(`Unable to read /host/proc/meminfo: ${e}`);
     }
 
-    const [disk0] = await si.fsSize();
+    const disks = await si.fsSize();
+    const disk0 = disks.find((disk) => disk.mount.startsWith('/host/root'));
 
     return {
       cpu: { load: currentLoad },


### PR DESCRIPTION
For some reason when I tried mounting ```/``` to ```/host/root``` instead of ```/mnt/host``` WSL displayed disk usage just fine and for some weird reason it picked the ```/mnt/c``` drive which is my actual disk space.