### PR TITLE
StopApp succes if app folder not found

### DIFF
--- a/packages/worker/src/services/app/app.executors.ts
+++ b/packages/worker/src/services/app/app.executors.ts
@@ -175,7 +175,8 @@ export class AppExecutors {
       this.logger.info(`Stopping app ${appId}`);
 
       const { appDirPath } = this.getAppPaths(appId);
-      const appFolderExists = await pathExists(appDirPath);
+      const configJsonPath = path.join(appDirPath, 'config.json');
+      const appFolderExists = await pathExists(configJsonPath);
 
       if (!appFolderExists) {
         this.logger.error(`App ${appId} folder not found`);

--- a/packages/worker/src/services/app/app.executors.ts
+++ b/packages/worker/src/services/app/app.executors.ts
@@ -174,6 +174,14 @@ export class AppExecutors {
       SocketManager.emit({ type: 'app', event: 'status_change', data: { appId } });
       this.logger.info(`Stopping app ${appId}`);
 
+      const { appDirPath } = this.getAppPaths(appId);
+      const appFolderExists = await pathExists(appDirPath);
+
+      if (!appFolderExists) {
+        this.logger.error(`App ${appId} folder not found`);
+        return { success: true, message: `App ${appId} folder not found` };
+      }
+
       await this.ensureAppDir(appId);
 
       if (!skipEnvGeneration) {


### PR DESCRIPTION
Hey @meienberger what do you think of this for issue #1002, Do you think is the right approach?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Implemented a check to ensure the application folder exists before performing operations, preventing errors related to non-existent directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->