### PR TITLE
feat(worker): auto download the latest compose version

### DIFF
--- a/packages/worker/Dockerfile
+++ b/packages/worker/Dockerfile
@@ -24,14 +24,15 @@ WORKDIR /app
 ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 
+RUN COMPOSE_VERSION=$(curl -sL https://api.github.com/repos/docker/compose/releases/latest | grep tag_name | cut -d '"' -f4)
+
 RUN echo "Building for ${TARGETARCH}"
+RUN echo "Using docker-compose ${COMPOSE_VERSION}"
 
 RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-aarch64"; \
+  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-aarch64"; \
   elif [ "${TARGETARCH}" = "amd64" ]; then \
-  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-x86_64"; \
-  else \
-  echo "Unsupported architecture"; \
+  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64"; \
   fi
 
 RUN chmod +x docker-binary

--- a/packages/worker/Dockerfile.dev
+++ b/packages/worker/Dockerfile.dev
@@ -11,12 +11,15 @@ RUN apk upgrade --update-cache --available && \
 ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 
+RUN COMPOSE_VERSION=$(curl -sL https://api.github.com/repos/docker/compose/releases/latest | grep tag_name | cut -d '"' -f4)
+
 RUN echo "Building for ${TARGETARCH}"
+RUN echo "Using docker-compose ${COMPOSE_VERSION}"
 
 RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-aarch64"; \
+  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-aarch64"; \
   elif [ "${TARGETARCH}" = "amd64" ]; then \
-  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-x86_64"; \
+  curl -L -o docker-binary "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64"; \
   fi
 
 RUN chmod +x docker-binary


### PR DESCRIPTION
It is better to auto download the docker compose version since when running ```apk add docker-compose``` which was the older method did it for us. So now that we download the compose command manually we need to replicate the apk function and auto get the latest version too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the worker's Dockerfile to dynamically fetch the latest version of docker-compose, ensuring the use of up-to-date dependencies for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->