### PR TITLE
feat/update all apps

### DIFF
--- a/src/app/(dashboard)/app-store/[id]/components/UpdateModal/UpdateModal.tsx
+++ b/src/app/(dashboard)/app-store/[id]/components/UpdateModal/UpdateModal.tsx
@@ -5,8 +5,8 @@ import { AppInfo } from '@runtipi/shared';
 import { Button } from '@/components/ui/Button';
 
 interface IProps {
-  newVersion: string;
-  info: Pick<AppInfo, 'name'>;
+  newVersion: string | null;
+  info: Pick<AppInfo, 'name'> | null;
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
@@ -19,11 +19,11 @@ export const UpdateModal: React.FC<IProps> = ({ info, newVersion, isOpen, onClos
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent size="sm">
         <DialogHeader>
-          <h5 className="modal-title">{t('title', { name: info.name })}</h5>
+          <h5 className="modal-title">{t('title', { name: info?.name || 'all apps' })}</h5>
         </DialogHeader>
         <DialogDescription>
           <div className="text-muted">
-            {t('subtitle1')} <b>{newVersion}</b> ?<br />
+            {newVersion && (<>{t('subtitle1')} <b>{newVersion}</b> ?<br /></>)}
             {t('subtitle2')}
           </div>
         </DialogDescription>

--- a/src/app/(dashboard)/apps/components/UpdateAllButton/UpdateAllButton.tsx
+++ b/src/app/(dashboard)/apps/components/UpdateAllButton/UpdateAllButton.tsx
@@ -1,0 +1,56 @@
+import { IconDownload } from '@tabler/icons-react';
+import React from 'react';
+import { toast } from 'react-hot-toast';
+import { Button } from '@/components/ui/Button';
+import clsx from 'clsx';
+import { UpdateModal } from 'src/app/(dashboard)/app-store/[id]/components/UpdateModal/';
+import { useDisclosure } from '@/client/hooks/useDisclosure';
+import { AppService } from '@/server/services/apps/apps.service';
+import { useAction } from 'next-safe-action/hook';
+import { updateAppAction } from '@/actions/app-actions/update-app-action';
+
+type UpdateAllButtonProps = {
+  apps: Awaited<ReturnType<AppService['getApp']>>[];
+}
+
+export const UpdateAllButton: React.FC<UpdateAllButtonProps> = ({apps}) => {
+
+  const updateDisclosure = useDisclosure();
+
+  const updateMutation = useAction(updateAppAction, {
+    onError: (e) => {
+      if (e.serverError) toast.error(e.serverError);
+    },
+    onExecute: () => {
+      updateDisclosure.close();
+      // setOptimisticStatus('updating');
+    },
+  });
+
+  const openModal = () => {
+    updateDisclosure.open();
+  }
+
+  const updateAll = () => {
+    apps.forEach((app) => {
+      updateMutation.execute({ id: app.id });
+    })
+  }
+
+  return (
+    <>
+      <UpdateModal
+        onConfirm={() => updateAll()}
+        isOpen={updateDisclosure.isOpen}
+        onClose={updateDisclosure.close}
+        info={null}
+        newVersion={null} />
+      <div className='d-flex justify-content-end'>
+        <Button className={clsx('me-2 px-4 mt-2', [`btn-green`])} onClick={openModal}>
+          Update all
+          {IconDownload && <IconDownload className='ms-1' size={18} />}
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/src/app/(dashboard)/apps/components/UpdateAllButton/UpdateAllButton.tsx
+++ b/src/app/(dashboard)/apps/components/UpdateAllButton/UpdateAllButton.tsx
@@ -5,25 +5,19 @@ import { Button } from '@/components/ui/Button';
 import clsx from 'clsx';
 import { UpdateModal } from 'src/app/(dashboard)/app-store/[id]/components/UpdateModal/';
 import { useDisclosure } from '@/client/hooks/useDisclosure';
-import { AppService } from '@/server/services/apps/apps.service';
 import { useAction } from 'next-safe-action/hook';
-import { updateAppAction } from '@/actions/app-actions/update-app-action';
+import { updateAllAppsAction } from '@/actions/app-actions/update-app-action';
 
-type UpdateAllButtonProps = {
-  apps: Awaited<ReturnType<AppService['getApp']>>[];
-}
-
-export const UpdateAllButton: React.FC<UpdateAllButtonProps> = ({apps}) => {
+export const UpdateAllButton: React.FC = () => {
 
   const updateDisclosure = useDisclosure();
 
-  const updateMutation = useAction(updateAppAction, {
+  const updateAllMutation = useAction(updateAllAppsAction, {
     onError: (e) => {
       if (e.serverError) toast.error(e.serverError);
     },
     onExecute: () => {
       updateDisclosure.close();
-      // setOptimisticStatus('updating');
     },
   });
 
@@ -32,9 +26,7 @@ export const UpdateAllButton: React.FC<UpdateAllButtonProps> = ({apps}) => {
   }
 
   const updateAll = () => {
-    apps.forEach((app) => {
-      updateMutation.execute({ id: app.id });
-    })
+    updateAllMutation.execute();
   }
 
   return (

--- a/src/app/(dashboard)/apps/components/UpdateAllButton/UpdateAllButtonWrapper.tsx
+++ b/src/app/(dashboard)/apps/components/UpdateAllButton/UpdateAllButtonWrapper.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import React from 'react';
+import { AppService } from '@/server/services/apps/apps.service';
+import { UpdateAllButton } from "./UpdateAllButton";
+
+
+type UpdateAllButtonWrapperProps = {
+  apps: Awaited<ReturnType<AppService['getApp']>>[];
+}
+
+export const UpdateAllButtonWrapper: React.FC<UpdateAllButtonWrapperProps> = ({apps}) => {
+
+  return (
+    <UpdateAllButton apps={apps}/>
+  )
+}

--- a/src/app/(dashboard)/apps/components/UpdateAllButton/UpdateAllButtonWrapper.tsx
+++ b/src/app/(dashboard)/apps/components/UpdateAllButton/UpdateAllButtonWrapper.tsx
@@ -1,17 +1,11 @@
 'use client'
 
 import React from 'react';
-import { AppService } from '@/server/services/apps/apps.service';
 import { UpdateAllButton } from "./UpdateAllButton";
 
-
-type UpdateAllButtonWrapperProps = {
-  apps: Awaited<ReturnType<AppService['getApp']>>[];
-}
-
-export const UpdateAllButtonWrapper: React.FC<UpdateAllButtonWrapperProps> = ({apps}) => {
+export const UpdateAllButtonWrapper: React.FC = () => {
 
   return (
-    <UpdateAllButton apps={apps}/>
+    <UpdateAllButton />
   )
 }

--- a/src/app/(dashboard)/apps/page.tsx
+++ b/src/app/(dashboard)/apps/page.tsx
@@ -38,7 +38,7 @@ export default async function Page() {
 
   return (
     <>
-      { aviableUpdates.length >= 0 && <UpdateAllButtonWrapper apps={aviableUpdates} /> }
+      { aviableUpdates.length >= 0 && <UpdateAllButtonWrapper /> }
         
       {installedApps.length === 0 && <EmptyPage title="apps.my-apps.empty-title" subtitle="apps.my-apps.empty-subtitle" redirectPath="/app-store" actionLabel="apps.my-apps.empty-action" />}
       <div className="row row-cards " data-testid="apps-list">

--- a/src/app/(dashboard)/apps/page.tsx
+++ b/src/app/(dashboard)/apps/page.tsx
@@ -6,6 +6,7 @@ import { getTranslatorFromCookie } from '@/lib/get-translator';
 import { AppTile } from '@/components/AppTile';
 import Link from 'next/link';
 import clsx from 'clsx';
+import { UpdateAllButtonWrapper } from 'src/app/(dashboard)/apps/components/UpdateAllButton/UpdateAllButtonWrapper';
 import { EmptyPage } from '../../components/EmptyPage';
 import styles from './page.module.css';
 
@@ -20,6 +21,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Page() {
   const appsService = new AppServiceClass(db);
   const installedApps = await appsService.installedApps();
+  const aviableUpdates = installedApps.filter(app => Number(app.version) < Number(app.latestVersion));
 
   const renderApp = (app: (typeof installedApps)[number]) => {
     const updateAvailable = Number(app.version) < Number(app.latestVersion);
@@ -36,6 +38,8 @@ export default async function Page() {
 
   return (
     <>
+      { aviableUpdates.length >= 0 && <UpdateAllButtonWrapper apps={aviableUpdates} /> }
+        
       {installedApps.length === 0 && <EmptyPage title="apps.my-apps.empty-title" subtitle="apps.my-apps.empty-subtitle" redirectPath="/app-store" actionLabel="apps.my-apps.empty-action" />}
       <div className="row row-cards " data-testid="apps-list">
         {installedApps?.map(renderApp)}

--- a/src/app/actions/app-actions/update-app-action.ts
+++ b/src/app/actions/app-actions/update-app-action.ts
@@ -9,6 +9,7 @@ import { handleActionError } from '../utils/handle-action-error';
 import { ensureUser } from '../utils/ensure-user';
 
 const input = z.object({ id: z.string() });
+const updateAllInput = z.void();
 
 /**
  * Given an app id, updates the app to the latest version
@@ -24,6 +25,21 @@ export const updateAppAction = action(input, async ({ id }) => {
     revalidatePath(`/app/${id}`);
     revalidatePath(`/app-store/${id}`);
 
+    return { success: true };
+  } catch (e) {
+    return handleActionError(e);
+  }
+});
+ 
+export const updateAllAppsAction = action(updateAllInput, async () => {
+  const appsService = new AppServiceClass(db);
+  const installedApps = await appsService.installedApps();
+
+  try {
+    installedApps.forEach((app) => {
+      updateAppAction({ id: app.id });
+    });
+  
     return { success: true };
   } catch (e) {
     return handleActionError(e);

--- a/src/app/actions/app-actions/update-app-action.ts
+++ b/src/app/actions/app-actions/update-app-action.ts
@@ -34,9 +34,10 @@ export const updateAppAction = action(input, async ({ id }) => {
 export const updateAllAppsAction = action(updateAllInput, async () => {
   const appsService = new AppServiceClass(db);
   const installedApps = await appsService.installedApps();
+  const aviableUpdates = installedApps.filter(app => Number(app.version) < Number(app.latestVersion));
 
   try {
-    installedApps.forEach((app) => {
+    aviableUpdates.forEach((app) => {
       updateAppAction({ id: app.id });
     });
   


### PR DESCRIPTION
Closes #1018

With `updateAllAppsAction` maybe we can have performance issues if there is a lot of apps to update. Maybe a queue update is needed?

And I'm having trouble positioning the button, I wanted to put it in the LayoutActions like `if (pathname ==='/apps') { <UpdateAllButtonWrapper /> }` but i cant because LayoutActions is a client component, and I'm kind of new in next js.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented an "Update All" button to allow users to update all apps simultaneously.
  - Added a confirmation modal for the "Update All" action with improved handling for app information display.

- **Enhancements**
  - Enhanced app update modal to better manage and display app names and version information, even when some details are not available.

- **Bug Fixes**
  - Addressed potential issues with displaying null or missing app information during the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->