### PR TITLE
feat(apps): add ability to deprecate apps from the app store

### DIFF
--- a/packages/shared/src/schemas/app-schemas.ts
+++ b/packages/shared/src/schemas/app-schemas.ts
@@ -52,6 +52,7 @@ export const formFieldSchema = z.object({
 export const appInfoSchema = z.object({
   id: z.string(),
   available: z.boolean(),
+  deprecated: z.boolean().optional().default(false),
   port: z.number().min(1).max(65535),
   name: z.string(),
   description: z.string().optional().default(''),

--- a/src/app/(dashboard)/app-store/[id]/components/AppDetailsTabs/AppDetailsTabs.tsx
+++ b/src/app/(dashboard)/app-store/[id]/components/AppDetailsTabs/AppDetailsTabs.tsx
@@ -1,4 +1,4 @@
-import { IconExternalLink } from '@tabler/icons-react';
+import { IconAlertCircle, IconExternalLink } from '@tabler/icons-react';
 import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTranslations } from 'next-intl';
@@ -20,6 +20,19 @@ export const AppDetailsTabs: React.FC<IProps> = ({ info }) => {
         <TabsTrigger value="info">{t('base-info')}</TabsTrigger>
       </TabsList>
       <TabsContent value="description">
+        {info.deprecated && (
+          <div className="alert alert-danger" role="alert">
+            <div className="d-flex">
+              <div>
+                <IconAlertCircle />
+              </div>
+              <div className="ms-2">
+                <h4 className="alert-title">{t('deprecated-alert-title')}</h4>
+                <div className="text-secondary">{t('deprecated-alert-subtitle')} </div>
+              </div>
+            </div>
+          </div>
+        )}
         <Markdown className="markdown">{info.description}</Markdown>
       </TabsContent>
       <TabsContent value="info">

--- a/src/app/(dashboard)/app-store/helpers/table.helpers.ts
+++ b/src/app/(dashboard)/app-store/helpers/table.helpers.ts
@@ -41,9 +41,11 @@ export const sortTable = (params: SortParams) => {
   });
 
   if (category) {
-    return sortedData.filter((app) => app.categories.some((c) => c === category)).filter((app) => app.name.toLowerCase().includes(search.toLowerCase()));
+    return sortedData
+      .filter((app) => app.categories.some((c) => c === category))
+      .filter((app) => app.name.toLowerCase().includes(search.toLowerCase()) && !app.deprecated);
   }
-  return sortedData.filter((app) => app.name.toLowerCase().includes(search.toLowerCase()));
+  return sortedData.filter((app) => app.name.toLowerCase().includes(search.toLowerCase()) && !app.deprecated);
 };
 
 export const colorSchemeForCategory: Record<AppCategory, string> = {

--- a/src/client/components/AppTile/AppTile.tsx
+++ b/src/client/components/AppTile/AppTile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { IconDownload } from '@tabler/icons-react';
+import { IconAlertCircle, IconDownload } from '@tabler/icons-react';
 import { Tooltip } from 'react-tooltip';
 import type { AppStatus as AppStatusEnum } from '@/server/db/schema';
 import { useTranslations } from 'next-intl';
@@ -11,7 +11,7 @@ import { AppStatus } from '@/components/AppStatus';
 import { limitText } from '@/lib/helpers/text-helpers';
 import styles from './AppTile.module.scss';
 
-type AppTileInfo = Pick<AppInfo, 'id' | 'name' | 'description' | 'short_desc'>;
+type AppTileInfo = Pick<AppInfo, 'id' | 'name' | 'description' | 'short_desc' | 'deprecated'>;
 
 export const AppTile: React.FC<{ app: AppTileInfo; status: AppStatusEnum; updateAvailable: boolean }> = ({ app, status, updateAvailable }) => {
   const t = useTranslations('apps');
@@ -42,6 +42,16 @@ export const AppTile: React.FC<{ app: AppTileInfo; status: AppStatusEnum; update
             </Tooltip>
             <div className="updateAvailable ribbon bg-green ribbon-top">
               <IconDownload size={20} />
+            </div>
+          </>
+        )}
+        {app.deprecated && (
+          <>
+            <Tooltip className="tooltip" anchorSelect=".deprecated">
+              {t('deprecated')}
+            </Tooltip>
+            <div className="deprecated ribbon bg-red">
+              <IconAlertCircle />
             </div>
           </>
         )}

--- a/src/client/messages/en.json
+++ b/src/client/messages/en.json
@@ -116,6 +116,7 @@
     "status-installing": "Installing",
     "status-uninstalling": "Uninstalling",
     "update-available": "Update available",
+    "deprecated": "This app is deprecated",
     "my-apps": {
       "title": "My Apps",
       "empty-title": "No app installed",
@@ -148,6 +149,8 @@
       "website": "Website",
       "supported-arch": "Supported architectures",
       "choose-open-method": "Choose open method",
+      "deprecated-alert-title": "This app is deprecated",
+      "deprecated-alert-subtitle": "A breaking change in this app prevents it from being updated automatically. You can still use this version and update it manually, but it is recommended to switch to a newer version and migrate your data. You can find an updated version in the app store under the same name.",
       "categories": {
         "data": "Data",
         "network": "Network",

--- a/src/server/tests/apps.factory.ts
+++ b/src/server/tests/apps.factory.ts
@@ -64,6 +64,7 @@ const createApp = async (props: IProps, database: TestDatabase) => {
 
   const appInfo: AppInfo = {
     id: randomId,
+    deprecated: false,
     port: faker.number.int({ min: 3000, max: 5000 }),
     available: true,
     form_fields: [


### PR DESCRIPTION
# Purpose
App store maintainers sometimes need to deprecate an app and add a new version. It could be because of a wrong config was shipped or a major breaking changed happened in a new version of the app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an alert for deprecated apps in the app store dashboard.

- **Enhancements**
  - App store listings now filter and prioritize non-deprecated apps.

- **User Interface**
  - Added visual indicators for deprecated apps across the app interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->