### PR TITLE
feat(dev): restart dashboard unless-stopped

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -115,6 +115,7 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     container_name: tipi-dashboard
+    restart: unless-stopped
     depends_on:
       tipi-db:
         condition: service_healthy


### PR DESCRIPTION
Sometimes during development, the dashboard crashes, so with this policy it will restart automaticallyl.