### PR TITLE
Enhance: moved 'Forgot password?' under Login button

### DIFF
--- a/src/app/(auth)/login/components/LoginForm/LoginForm.tsx
+++ b/src/app/(auth)/login/components/LoginForm/LoginForm.tsx
@@ -48,9 +48,6 @@ export const LoginForm: React.FC<IProps> = ({ loading, onSubmit }) => {
         className="mb-3"
         placeholder={t('AUTH_FORM_EMAIL_PLACEHOLDER')}
       />
-      <span className="form-label-description">
-        <Link href="/reset-password">{t('AUTH_FORM_FORGOT')}</Link>
-      </span>
       <Input
         {...register('password')}
         name="password"
@@ -64,6 +61,9 @@ export const LoginForm: React.FC<IProps> = ({ loading, onSubmit }) => {
       <Button disabled={isDisabled} loading={loading} type="submit" className="btn btn-primary w-100">
         {t('AUTH_LOGIN_SUBMIT')}
       </Button>
+      <div className="form-text text-center">
+        <Link href="/reset-password">{t('AUTH_FORM_FORGOT')}</Link>
+      </div>
     </form>
   );
 };


### PR DESCRIPTION
The position of the password reset used to be right above the password field to the right. I have moved it to be under the Login button and centered it. 
This way, a user will not have to press additional tab key presses on their keyboard to login. This should close #1066.

P.S.: I see the issue was assigned to someone else. However, since it has been as month without updates I decided to take it anyway.

![image](https://github.com/runtipi/runtipi/assets/7281018/902d74d6-1b95-4752-949f-346a32129460)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the Login form layout for improved readability and design consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->