### PR TITLE
chore: support arm64 on nightly

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -31,7 +31,7 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             TIPI_VERSION=nightly
           file: ./packages/worker/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/worker:nightly
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/worker:buildcache
@@ -63,7 +63,7 @@ jobs:
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             TIPI_VERSION=nightly
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ghcr.io/runtipi/runtipi:nightly
           cache-from: type=registry,ref=ghcr.io/runtipi/runtipi:buildcache


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Expanded Docker build platforms to include `linux/arm64` alongside `linux/amd64` for the `worker` and `runtipi` images, enhancing compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->