### PR TITLE
chore: add pi image builds on release workflows

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Dispatch the release action
         uses: codex-/return-dispatch@v1
         with:
-          token: ${{ secrets.PI_IMAGE }}
+          token: ${{ secrets.PAT_CLI }}
           ref: main
           repo: raspberrypi
           owner: runtipi

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -145,6 +145,20 @@ jobs:
           name: cli
           path: bin
 
+  build-pi-image:
+    runs-on: ubuntu-latest
+    needs: create-tag
+    steps:
+      - name: Dispatch the release action
+        uses: codex-/return-dispatch@v1
+        with:
+          token: ${{ secrets.PI_IMAGE }}
+          ref: main
+          repo: raspberrypi
+          owner: runtipi
+          workflow: beta-release.yml
+          workflow_inputs: '{ "version": "${{ needs.create-tag.outputs.tagname }}" }'
+
   publish-release:
     runs-on: ubuntu-latest
     needs: [create-tag, build-images, build-cli, build-worker]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,20 @@ jobs:
           name: cli
           path: bin
 
+  build-pi-image:
+    runs-on: ubuntu-latest
+    needs: create-tag
+    steps:
+      - name: Dispatch the release action
+        uses: codex-/return-dispatch@v1
+        with:
+          token: ${{ secrets.PI_IMAGE }}
+          ref: main
+          repo: raspberrypi
+          owner: runtipi
+          workflow: release.yml
+          workflow_inputs: '{ "version": "${{ needs.create-tag.outputs.tagname }}" }'
+
   publish-release:
     runs-on: ubuntu-latest
     needs: [create-tag, build-images, build-worker, build-cli]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Dispatch the release action
         uses: codex-/return-dispatch@v1
         with:
-          token: ${{ secrets.PI_IMAGE }}
+          token: ${{ secrets.PAT_CLI }}
           ref: main
           repo: raspberrypi
           owner: runtipi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Introduced a feature to automatically create a Raspberry Pi image as part of the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->