### PR TITLE
Add `new` label to app tiles in the app store

### DIFF
--- a/packages/shared/src/schemas/app-schemas.ts
+++ b/packages/shared/src/schemas/app-schemas.ts
@@ -80,6 +80,7 @@ export const appInfoSchema = z.object({
   gid: z.number().optional(),
   dynamic_config: z.boolean().optional().default(false),
   min_tipi_version: z.string().optional(),
+  created: z.number().int().min(0).refine((v) => v < Date.now()).optional().default(0),
 });
 
 // Derived types

--- a/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
+++ b/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
@@ -25,7 +25,10 @@ export const AppStoreTile: React.FC<{ app: App }> = ({ app }) => {
       <div key={app.id} className="d-flex overflow-hidden align-items-center py-2 ps-2">
         <AppLogo className={styles.logo} id={app.id} />
         <div className="card-body">
-          <h3 className="text-bold h-3 mb-2">{limitText(app.name, 20)}</h3>
+          <div className="d-flex align-items-center" style={{"columnGap": "0.75rem"}}>
+          	<h3 className="text-bold h-3 mb-2">{limitText(app.name, 20)}</h3>
+          	{app.created + (14 * 24 * 60 * 60 * 1000) > Date.now() ? <div className="text-white badge me-1 bg-green">{t("APP_NEW")}</div> : null}
+          </div>
           <p className="text-muted text-nowrap mb-2">{limitText(app.short_desc, 30)}</p>
           {app.categories?.map((category) => (
             <div className={`text-white badge me-1 bg-${colorSchemeForCategory[category]}`} key={`${app.id}-${category}`}>

--- a/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
+++ b/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
@@ -19,6 +19,7 @@ type App = {
 
 export const AppStoreTile: React.FC<{ app: App }> = ({ app }) => {
   const t = useTranslations();
+  const isNewApp = app.created + (14 * 24 * 60 * 60 * 1000) > Date.now();
 
   return (
     <Link aria-label={app.name} className={clsx(styles.appTile)} href={`/app-store/${app.id}`} passHref>
@@ -27,7 +28,7 @@ export const AppStoreTile: React.FC<{ app: App }> = ({ app }) => {
         <div className="card-body">
           <div className="d-flex align-items-center" style={{"columnGap": "0.75rem"}}>
           	<h3 className="text-bold h-3 mb-2">{limitText(app.name, 20)}</h3>
-          	{app.created + (14 * 24 * 60 * 60 * 1000) > Date.now() ? <div className="text-white badge me-1 bg-green">{t("APP_NEW")}</div> : null}
+          	{isNewApp ? <div className="text-white badge me-1 bg-green">{t("APP_NEW")}</div> : null}
           </div>
           <p className="text-muted text-nowrap mb-2">{limitText(app.short_desc, 30)}</p>
           {app.categories?.map((category) => (

--- a/src/server/services/apps/apps.helpers.ts
+++ b/src/server/services/apps/apps.helpers.ts
@@ -69,13 +69,14 @@ export const getAvailableApps = async () => {
       return null;
     })
     .filter(notEmpty)
-    .map(({ id, categories, name, short_desc, deprecated, supported_architectures }) => ({
+    .map(({ id, categories, name, short_desc, deprecated, supported_architectures, created }) => ({
       id,
       categories,
       name,
       short_desc,
       deprecated,
       supported_architectures,
+      created,
     }));
 
   return apps;


### PR DESCRIPTION
This PR addresses issue #899.

### Changes
- A new `created` field for `config.json`. It stores the time the app was added to the app store as a UNIX timestamp (with milliseconds). It should ideally be set by CI when a new app is merged.
- API also returns app creation date when queried for apps.
- App store tile code now shows a `NEW` label next to the title if the app is less than 2 weeks old. Comparison happens on client using the timestamp provided by the API.