### PR TITLE
Update regex in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,8 +45,8 @@ while [ -n "${1-}" ]; do
   shift
 done
 
-OS="$(cat /etc/[A-Za-z]*[_-][rv]e[lr]* | grep "^ID=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
-SUB_OS="$(cat /etc/[A-Za-z]*[_-][rv]e[lr]* | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
+OS="$(cat $(ls -p /etc | grep -v / | grep [A-Za-z]*[_-][rv]e[lr] | awk '{print "/etc/" $1}') | grep "^ID=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
+SUB_OS="$(cat $(ls -p /etc | grep -v / | grep [A-Za-z]*[_-][rv]e[lr] | awk '{print "/etc/" $1}') | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
 
 function install_generic() {
   local dependency="${1}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ while [ -n "${1-}" ]; do
   shift
 done
 
-OS="$(cat $(ls -p /etc | grep -v / | grep [A-Za-z]*[_-][rv]e[lr] | awk '{print "/etc/" $1}') | grep "^ID=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
+OS="$(grep -h "^ID=" /etc/*[_-][rv]e[lr]* 2>/dev/null | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
 SUB_OS="$(cat $(ls -p /etc | grep -v / | grep [A-Za-z]*[_-][rv]e[lr] | awk '{print "/etc/" $1}') | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
 
 function install_generic() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,7 +46,7 @@ while [ -n "${1-}" ]; do
 done
 
 OS="$(grep -h "^ID=" /etc/*[_-][rv]e[lr]* 2>/dev/null | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
-SUB_OS="$(cat $(ls -p /etc | grep -v / | grep [A-Za-z]*[_-][rv]e[lr] | awk '{print "/etc/" $1}') | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
+SUB_OS="$(grep -h "^ID_LIKE=" /etc/*[_-][rv]e[lr]* 2>/dev/null | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
 
 function install_generic() {
   local dependency="${1}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,7 +46,7 @@ while [ -n "${1-}" ]; do
 done
 
 OS="$(cat $(ls -p /etc | grep -v / | grep [A-Za-z]*[_-][rv]e[lr] | awk '{print "/etc/" $1}') | grep "^ID=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
-SUB_OS="$(cat $(ls -p /etc | grep -v / | grep [A-Za-z]*[_-][rv]e[lr] | awk '{print "/etc/" $1}') | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
+SUB_OS="$(cat $(ls -p /etc | grep -v / | grep [A-Za-z]*[_-][rv]e[lr] | awk '{print "/etc/" $1}') | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
 
 function install_generic() {
   local dependency="${1}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,8 +45,8 @@ while [ -n "${1-}" ]; do
   shift
 done
 
-OS="$(grep -h "^ID=" /etc/*[_-][rv]e[lr]* 2>/dev/null | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
-SUB_OS="$(grep -h "^ID_LIKE=" /etc/*[_-][rv]e[lr]* 2>/dev/null | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
+OS="$(cat $(ls -p /etc | grep -v / | grep "[A-Za-z]*[_-][rv]e[lr]" | awk '{print "/etc/" $1}') | grep "^ID=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
+SUB_OS="$(cat $(ls -p /etc | grep -v / | grep "[A-Za-z]*[_-][rv]e[lr]" | awk '{print "/etc/" $1}') | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
 
 function install_generic() {
   local dependency="${1}"


### PR DESCRIPTION
The OS detection in the install script relies on finding and reading files in `/etc` related to the OS version.

The regex currently used has no protection against directories, so if a directory matching the regex is encountered, the installer will try to `cat` it and fail. This problem can be observed on Linux Mint where an `upstream-release/` directory is present and the installer fails with:
```
cat /etc/upstream-release: Is a directory
```

This PR aims to update the regex used to only read files.