### PR TITLE
refactor(worker): create data directories with 777 so apps can access them

### DIFF
--- a/packages/shared/src/schemas/app-schemas.ts
+++ b/packages/shared/src/schemas/app-schemas.ts
@@ -80,6 +80,7 @@ export const appInfoSchema = z.object({
   gid: z.number().optional(),
   dynamic_config: z.boolean().optional().default(false),
   min_tipi_version: z.string().optional(),
+  createDirs: z.array(z.string()).optional()
 });
 
 // Derived types

--- a/packages/worker/src/services/app/app.executors.ts
+++ b/packages/worker/src/services/app/app.executors.ts
@@ -57,7 +57,7 @@ export class AppExecutors {
    * @param {string} appId - App id
    */
   private ensureAppDir = async (appId: string, form: AppEventForm) => {
-    const { appDirPath, appDataDirPath, repoPath } = this.getAppPaths(appId);
+    const { appDirPath, repoPath } = this.getAppPaths(appId);
     const dockerFilePath = path.join(DATA_DIR, 'apps', sanitizePath(appId), 'docker-compose.yml');
 
     if (!(await pathExists(dockerFilePath))) {


### PR DESCRIPTION
With this feature the worker can create directories under the app-data folder with 777 permissions so apps not running as root can access them. For example if in a docker compose file we added `- ${APP_DATA_DIR}/data/hello:/hello` because the `hello` directory doesn't exist docker will create it with root but then the app will not be able to access that hello directory so by creating the directory and setting its permissions before docker the app will be able to access it.