### PR TITLE
Add button to clear category selection in the app store

### DIFF
--- a/src/app/(dashboard)/app-store/components/CategorySelector/CategorySelector.tsx
+++ b/src/app/(dashboard)/app-store/components/CategorySelector/CategorySelector.tsx
@@ -3,6 +3,7 @@ import type { AppCategory } from '@runtipi/shared';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { iconForCategory } from '../../helpers/table.helpers';
+import { IconChevronDown, IconX } from '@tabler/icons-react';
 
 interface Props {
   onSelect: (value?: AppCategory) => void;
@@ -25,10 +26,18 @@ export const CategorySelector = ({ onSelect, className, initialValue }: Props) =
     onSelect(option);
   };
 
+  const handleClear = () => {
+    setValue(undefined);
+    onSelect(undefined);
+  }
+
   return (
     <Select value={value} onValueChange={handleChange}>
-      <SelectTrigger value={value} className={className}>
+      <SelectTrigger value={value} className={className} style={{paddingRight: '0.75rem', backgroundImage: 'none !important'}}>
         <SelectValue placeholder={t('APP_INSTALL_FORM_CHOOSE_OPTION')} />
+        <div style={{borderLeft: "1px solid #1f2e41", paddingLeft: "0.5rem"}} onClick={handleClear}>
+          {value ? <IconX size={18} color='white'/> : <IconChevronDown size={18} color='white'/>}
+        </div>
       </SelectTrigger>
       <SelectContent>
         {options?.map(({ value: category, icon: CategoryIcon, label }) => (


### PR DESCRIPTION
> [!Warning]
> This PR is currently a work in progress and nothing works at the moment!!!

Before the category selector component was moved to Radix UI, the dropdown would have an X button if an option was selected, giving users an option to clear their selection. This is currently impossible with Radix UI.

This PR aims to re-enable support for that by customizing the `CategorySelector` component to include a button with the functionality mentioned previously.

Preview of desired result:
![Screenshot from 2024-08-21 14-46-35](https://github.com/user-attachments/assets/166ab598-efe7-4e64-b0b2-b052802773da)