### PR TITLE
Make app labels in app store clickable

### DIFF
--- a/src/app/(dashboard)/app-store/components/AppStoreTable/AppStoreTable.tsx
+++ b/src/app/(dashboard)/app-store/components/AppStoreTable/AppStoreTable.tsx
@@ -13,7 +13,7 @@ interface IProps {
 }
 
 export const AppStoreTable: React.FC<IProps> = ({ initialData }) => {
-  const { category, search } = useAppStoreState();
+  const { setCategory, category, search } = useAppStoreState();
 
   async function searchApps({ pageParam }: { pageParam?: string }) {
     const url = new URL('/api/app-store', window.location.origin);
@@ -63,7 +63,7 @@ export const AppStoreTable: React.FC<IProps> = ({ initialData }) => {
       <div className="row row-cards">
         {apps.map((app, index) => (
           <div ref={index === apps.length - 1 ? lastElementRef : null} key={app.id} className="cursor-pointer col-sm-6 col-lg-4 p-2 mt-4">
-            <AppStoreTile app={app} />
+            <AppStoreTile app={app} onClickCategory={setCategory} />
           </div>
         ))}
       </div>

--- a/src/app/(dashboard)/app-store/components/AppStoreTableActions/AppStoreTableActions.tsx
+++ b/src/app/(dashboard)/app-store/components/AppStoreTableActions/AppStoreTableActions.tsx
@@ -27,7 +27,7 @@ export const AppStoreTableActions = () => {
         placeholder={t('APP_STORE_SEARCH_PLACEHOLDER')}
         className={clsx('flex-fill mt-2 mt-md-0 me-md-2', styles.selector)}
       />
-      <CategorySelector initialValue={category} className={clsx('flex-fill mt-2 mt-md-0', styles.selector)} onSelect={setCategory} />
+      <CategorySelector value={category} className={clsx('flex-fill mt-2 mt-md-0', styles.selector)} onSelect={setCategory} />
     </div>
   );
 };

--- a/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
+++ b/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import type React from 'react';
-import { MouseEvent } from 'react';
+import type { MouseEvent } from 'react';
 import { colorSchemeForCategory } from '../../helpers/table.helpers';
 import styles from './AppStoreTile.module.scss';
 
@@ -41,7 +41,7 @@ export const AppStoreTile: React.FC<{ app: App, onClickCategory: (category: AppC
           </div>
           <p className="text-muted text-nowrap mb-2">{limitText(app.short_desc, 30)}</p>
           {app.categories?.map((category) => (
-            <button className={`text-white badge me-1 bg-${colorSchemeForCategory[category]}`} key={`${app.id}-${category}`} onClick={handleClick(category)}>
+            <button className={`text-white badge me-1 bg-${colorSchemeForCategory[category]}`} key={`${app.id}-${category}`} onClick={handleClick(category)} type="button">
               {t(`APP_CATEGORY_${category.toUpperCase() as Uppercase<typeof category>}`)}
             </button>
           ))}

--- a/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
+++ b/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
@@ -19,7 +19,7 @@ type App = {
   short_desc: string;
 };
 
-export const AppStoreTile: React.FC<{ app: App, onClickCategory: (category: AppCategory) => void }> = ({ app, onClickCategory }) => {
+export const AppStoreTile: React.FC<{ app: App; onClickCategory: (category: AppCategory) => void }> = ({ app, onClickCategory }) => {
   const t = useTranslations();
   const isNew = app.created_at + 14 * 24 * 60 * 60 * 1000 > Date.now();
 
@@ -27,8 +27,8 @@ export const AppStoreTile: React.FC<{ app: App, onClickCategory: (category: AppC
     return (event: MouseEvent) => {
       event.preventDefault();
       onClickCategory(category);
-    }
-  }
+    };
+  };
 
   return (
     <Link aria-label={app.name} className={clsx(styles.appTile)} href={`/app-store/${app.id}`} passHref>
@@ -41,7 +41,12 @@ export const AppStoreTile: React.FC<{ app: App, onClickCategory: (category: AppC
           </div>
           <p className="text-muted text-nowrap mb-2">{limitText(app.short_desc, 30)}</p>
           {app.categories?.map((category) => (
-            <button className={`text-white badge me-1 bg-${colorSchemeForCategory[category]}`} key={`${app.id}-${category}`} onClick={handleClick(category)} type="button">
+            <button
+              className={`text-white badge me-1 bg-${colorSchemeForCategory[category]}`}
+              key={`${app.id}-${category}`}
+              onClick={handleClick(category)}
+              type="button"
+            >
               {t(`APP_CATEGORY_${category.toUpperCase() as Uppercase<typeof category>}`)}
             </button>
           ))}

--- a/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
+++ b/src/app/(dashboard)/app-store/components/AppStoreTile/AppStoreTile.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import type React from 'react';
+import { MouseEvent } from 'react';
 import { colorSchemeForCategory } from '../../helpers/table.helpers';
 import styles from './AppStoreTile.module.scss';
 
@@ -18,9 +19,16 @@ type App = {
   short_desc: string;
 };
 
-export const AppStoreTile: React.FC<{ app: App }> = ({ app }) => {
+export const AppStoreTile: React.FC<{ app: App, onClickCategory: (category: AppCategory) => void }> = ({ app, onClickCategory }) => {
   const t = useTranslations();
   const isNew = app.created_at + 14 * 24 * 60 * 60 * 1000 > Date.now();
+
+  const handleClick = (category: AppCategory) => {
+    return (event: MouseEvent) => {
+      event.preventDefault();
+      onClickCategory(category);
+    }
+  }
 
   return (
     <Link aria-label={app.name} className={clsx(styles.appTile)} href={`/app-store/${app.id}`} passHref>
@@ -33,9 +41,9 @@ export const AppStoreTile: React.FC<{ app: App }> = ({ app }) => {
           </div>
           <p className="text-muted text-nowrap mb-2">{limitText(app.short_desc, 30)}</p>
           {app.categories?.map((category) => (
-            <div className={`text-white badge me-1 bg-${colorSchemeForCategory[category]}`} key={`${app.id}-${category}`}>
+            <button className={`text-white badge me-1 bg-${colorSchemeForCategory[category]}`} key={`${app.id}-${category}`} onClick={handleClick(category)}>
               {t(`APP_CATEGORY_${category.toUpperCase() as Uppercase<typeof category>}`)}
-            </div>
+            </button>
           ))}
         </div>
       </div>

--- a/src/app/(dashboard)/app-store/components/CategorySelector/CategorySelector.test.tsx
+++ b/src/app/(dashboard)/app-store/components/CategorySelector/CategorySelector.test.tsx
@@ -37,7 +37,7 @@ describe('Test: CategorySelector', () => {
     // arrange
     const onSelect = vi.fn();
     const className = 'test-class';
-    render(<CategorySelector onSelect={onSelect} className={className} initialValue="automation" />);
+    render(<CategorySelector onSelect={onSelect} className={className} value="automation" />);
 
     // assert
     expect(screen.getByText('Automation')).toBeInTheDocument();

--- a/src/app/(dashboard)/app-store/components/CategorySelector/CategorySelector.tsx
+++ b/src/app/(dashboard)/app-store/components/CategorySelector/CategorySelector.tsx
@@ -7,10 +7,10 @@ import { iconForCategory } from '../../helpers/table.helpers';
 interface Props {
   onSelect: (value?: AppCategory) => void;
   className?: string;
-  initialValue?: AppCategory;
+  value?: AppCategory;
 }
 
-export const CategorySelector = ({ onSelect, className, initialValue }: Props) => {
+export const CategorySelector = ({ onSelect, className, value }: Props) => {
   const t = useTranslations();
   const options = iconForCategory.map((category) => ({
     value: category.id,
@@ -18,10 +18,7 @@ export const CategorySelector = ({ onSelect, className, initialValue }: Props) =
     icon: category.icon,
   }));
 
-  const [value, setValue] = useState(initialValue);
-
   const handleChange = (option: AppCategory) => {
-    setValue(option);
     onSelect(option);
   };
 

--- a/src/app/(dashboard)/app-store/components/CategorySelector/CategorySelector.tsx
+++ b/src/app/(dashboard)/app-store/components/CategorySelector/CategorySelector.tsx
@@ -1,7 +1,6 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import type { AppCategory } from '@runtipi/shared';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
 import { iconForCategory } from '../../helpers/table.helpers';
 
 interface Props {


### PR DESCRIPTION
# Changes
- Turned app labels in the app store into buttons that set the selected category.
- `CategorySelector` does not maintain an internal state anymore

No issues are open for this, but I think it's something that users would expect. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the AppStoreTile component to allow direct interaction with category selections through a new onClickCategory prop, improving user engagement.
	- Updated the CategorySelector component to reflect the current category state dynamically, ensuring better synchronization with user selections.

- **Bug Fixes**
	- Improved accessibility and interactivity by replacing div elements with buttons in the AppStoreTile, aligning with semantic HTML practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->