### PR TITLE
Added new `interface` key to ports in the dynamic compose

### DIFF
--- a/packages/worker/src/config/__tests__/docker-templates.test.ts
+++ b/packages/worker/src/config/__tests__/docker-templates.test.ts
@@ -49,7 +49,7 @@ describe('getDockerCompose', async () => {
           { containerPort: 3000, hostPort: 4444, tcp: true },
           { containerPort: 3001, hostPort: 4445, udp: true },
           { containerPort: 3002, hostPort: 4446 },
-          { containerPort: 3003, hostPort: 4447, interface: "0.0.0.0" },
+          { containerPort: 3003, hostPort: 4447, interface: '0.0.0.0' },
         ],
       },
     ] satisfies ServiceInput[];

--- a/packages/worker/src/config/__tests__/docker-templates.test.ts
+++ b/packages/worker/src/config/__tests__/docker-templates.test.ts
@@ -49,6 +49,7 @@ describe('getDockerCompose', async () => {
           { containerPort: 3000, hostPort: 4444, tcp: true },
           { containerPort: 3001, hostPort: 4445, udp: true },
           { containerPort: 3002, hostPort: 4446 },
+          { containerPort: 3003, hostPort: 4447, interface: "0.0.0.0" },
         ],
       },
     ] satisfies ServiceInput[];

--- a/packages/worker/src/config/__tests__/docker-templates.test.ts
+++ b/packages/worker/src/config/__tests__/docker-templates.test.ts
@@ -102,6 +102,7 @@ describe('getDockerCompose', async () => {
             - 4444:3000/tcp
             - 4445:3001/udp
             - 4446:3002
+            - 0.0.0.0:4447:3003
           depends_on:
             - ${serviceName1}
       networks:

--- a/packages/worker/src/config/docker-templates.ts
+++ b/packages/worker/src/config/docker-templates.ts
@@ -33,7 +33,7 @@ const buildService = (params: Service, form: AppEventFormInput) => {
     if (form.openPort) {
       service.addPort({
         containerPort: params.internalPort,
-        hostPort: '${APP_PORT}',
+        hostPort: Number('${APP_PORT}'),
       });
     }
 

--- a/packages/worker/src/config/docker-templates.ts
+++ b/packages/worker/src/config/docker-templates.ts
@@ -33,7 +33,7 @@ const buildService = (params: Service, form: AppEventFormInput) => {
     if (form.openPort) {
       service.addPort({
         containerPort: params.internalPort,
-        hostPort: Number('${APP_PORT}'),
+        hostPort: '${APP_PORT}',
       });
     }
 

--- a/packages/worker/src/lib/docker/builders/schemas.ts
+++ b/packages/worker/src/lib/docker/builders/schemas.ts
@@ -30,7 +30,7 @@ export const serviceSchema = z.object({
         hostPort: z.number(),
         udp: z.boolean().optional(),
         tcp: z.boolean().optional(),
-        interface: z.string().optional()
+        interface: z.string().optional(),
       }),
     )
     .optional(),

--- a/packages/worker/src/lib/docker/builders/schemas.ts
+++ b/packages/worker/src/lib/docker/builders/schemas.ts
@@ -30,6 +30,7 @@ export const serviceSchema = z.object({
         hostPort: z.number(),
         udp: z.boolean().optional(),
         tcp: z.boolean().optional(),
+        interface: z.string().optional()
       }),
     )
     .optional(),

--- a/packages/worker/src/lib/docker/builders/service-builder.ts
+++ b/packages/worker/src/lib/docker/builders/service-builder.ts
@@ -2,9 +2,10 @@ import type { DependsOn } from './schemas';
 
 interface ServicePort {
   containerPort: number;
-  hostPort: number | string;
+  hostPort: number;
   tcp?: boolean;
   udp?: boolean;
+  interface?: string;
 }
 
 interface ServiceVolume {
@@ -126,17 +127,23 @@ export class ServiceBuilder {
       this.service.ports = [];
     }
 
+    let port_string = `${port.hostPort}:${port.containerPort}`;
+
+    if (port.interface) {
+      port_string = `${port.interface}:${port_string}`;
+    }
+
     if (!port.tcp && !port.udp) {
-      this.service.ports.push(`${port.hostPort}:${port.containerPort}`);
+      this.service.ports.push(port_string);
       return this;
     }
 
     if (port.tcp) {
-      this.service.ports.push(`${port.hostPort}:${port.containerPort}/tcp`);
+      this.service.ports.push(`${port_string}/tcp`);
     }
 
     if (port.udp) {
-      this.service.ports.push(`${port.hostPort}:${port.containerPort}/udp`);
+      this.service.ports.push(`${port_string}/udp`);
     }
 
     return this;

--- a/packages/worker/src/lib/docker/builders/service-builder.ts
+++ b/packages/worker/src/lib/docker/builders/service-builder.ts
@@ -2,7 +2,7 @@ import type { DependsOn } from './schemas';
 
 interface ServicePort {
   containerPort: number;
-  hostPort: number;
+  hostPort: number | string;
   tcp?: boolean;
   udp?: boolean;
   interface?: string;


### PR DESCRIPTION
# Changes
This PR implements an `interface` key when defining ports for an app with the dynamic compose. It is useful for apps like adguard, so they can bind to one specific interface (as opposed to all, which is the default).

# Example usage
```json
...
"addPorts": [
    {
        "hostPort": 53,
        "containerPort": 53,
        "tcp": true,
        "udp": true,
        "interface": "${NETWORK_INTERFACE:-0.0.0.0}"
    },
    {
        "hostPort": 853,
        "containerPort": 853,
        "tcp": true,
        "udp": true,
        "interface": "${NETWORK_INTERFACE:-0.0.0.0}"
     }
]
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional property `interface` for service configurations, enhancing flexibility.
	- Added support for additional service input configurations in Docker testing.

- **Bug Fixes**
	- Updated `hostPort` to ensure it is treated as a number, improving consistency in service definitions.

- **Refactor**
	- Revised logic for handling service ports to accommodate the new `interface` property in configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->