### PR TITLE
Add extra dynamic compose options

### DIFF
--- a/packages/worker/src/config/docker-templates.ts
+++ b/packages/worker/src/config/docker-templates.ts
@@ -15,7 +15,7 @@ const buildService = (params: Service, form: AppEventFormInput) => {
     .setName(params.name)
     .setEnvironment(params.environment)
     .setCommand(params.command)
-    .setHealthCheck(params.healthCheck)
+    .addHealthCheck(params.healthCheck)
     .setDependsOn(params.dependsOn)
     .addVolumes(params.volumes)
     .setRestartPolicy('unless-stopped')

--- a/packages/worker/src/lib/docker/builders/schemas.ts
+++ b/packages/worker/src/lib/docker/builders/schemas.ts
@@ -33,7 +33,7 @@ export const serviceSchema = z.object({
       }),
     )
     .optional(),
-  command: z.string().optional(),
+  command: z.string().optional().or(z.array(z.string()).optional()),
   volumes: z
     .array(
       z.object({
@@ -47,9 +47,11 @@ export const serviceSchema = z.object({
   healthCheck: z
     .object({
       test: z.string(),
-      interval: z.string(),
-      timeout: z.string(),
-      retries: z.number(),
+      interval: z.string().optional(),
+      timeout: z.string().optional(),
+      retries: z.number().optional(),
+      startInterval: z.string().optional(),
+      startPeriod: z.string().optional(),
     })
     .optional(),
   dependsOn: dependsOnSchema.optional(),

--- a/packages/worker/src/lib/docker/builders/service-builder.ts
+++ b/packages/worker/src/lib/docker/builders/service-builder.ts
@@ -1,4 +1,4 @@
-import type { DependsOn } from './schemas';
+import type { DependsOn, serviceSchema } from './schemas';
 
 interface ServicePort {
   containerPort: number;
@@ -15,9 +15,11 @@ interface ServiceVolume {
 
 interface HealthCheck {
   test: string;
-  interval: string;
-  timeout: string;
-  retries: number;
+  interval?: string;
+  timeout?: string;
+  retries?: number;
+  start_interval?: string;
+  start_period?: string;
 }
 
 interface Ulimits {
@@ -30,7 +32,7 @@ export interface BuilderService {
   containerName: string;
   restart: 'always' | 'unless-stopped' | 'on-failure';
   environment?: Record<string, string>;
-  command?: string;
+  command?: string | string[];
   volumes?: string[];
   ports?: string[];
   healthCheck?: HealthCheck;
@@ -228,7 +230,7 @@ export class ServiceBuilder {
    * service.setCommand('npm run start');
    * ```
    */
-  setCommand(command?: string) {
+  setCommand(command?: string | string[]) {
     if (command) {
       this.service.command = command;
     }
@@ -237,12 +239,12 @@ export class ServiceBuilder {
   }
 
   /**
-   * Sets the health check for the service.
-   * @param {HealthCheck} healthCheck The health check to set for the service.
+   * Adds the health check for the service.
+   * @param {HealthCheck} healthCheck The health check to add for the service.
    * @example
    * ```typescript
    * const service = new ServiceBuilder();
-   * service.setHealthCheck({
+   * service.addHealthCheck({
    *    test: 'curl --fail http://localhost:3000 || exit 1',
    *    retries: 3,
    *    interval: '30s',
@@ -250,9 +252,16 @@ export class ServiceBuilder {
    * });
    *  ```
    */
-  setHealthCheck(healthCheck?: HealthCheck) {
+  addHealthCheck(healthCheck?: typeof serviceSchema._type.healthCheck) {
     if (healthCheck) {
-      this.service.healthCheck = healthCheck;
+      this.service.healthCheck = {
+        test: healthCheck.test,
+        retries: healthCheck.retries,
+        interval: healthCheck.interval,
+        timeout: healthCheck.timeout,
+        start_interval: healthCheck.startInterval,
+        start_period: healthCheck.startPeriod,
+      };
     }
 
     return this;


### PR DESCRIPTION
# Changes
This PR makes the following changes to the dynamic compose schema:
- All healthcheck options for the dynamic compose become optional, except for `test` and 2 new ones are added: `startPeriod` and `startInterval`.
- The `command` field now also accepts an array, just like normal Docker Compose files. It should be noted that due to the way the JS objects are converted to YAML, it becomes a multi-line sequence instead of a compact single-line one. Both are functionally equivalent.