### PR TITLE
Introducing Tipi Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Docker Image Size](https://badgen.net/docker/size/meienberger/runtipi?icon=docker&label=image%20size)](https://hub.docker.com/r/meienberger/runtipi/)
 ![Build](https://github.com/runtipi/runtipi/workflows/Tipi%20CI/badge.svg)
 [![Crowdin](https://badges.crowdin.net/runtipi/localized.svg)](https://crowdin.com/project/runtipi)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Tipi%20Guru-006BFF)](https://gurubase.io/g/tipi)
 
 > [!NOTE]
 > Tipi is built with TypeScript, Next.js app router and Drizzle ORM! If you want to collaborate on a cool project, join the discussion on Discord!


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Tipi Guru](https://gurubase.io/g/tipi) to Gurubase. Tipi Guru uses the data from this repo and data from the [docs](https://www.runtipi.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Tipi Guru", which highlights that Tipi now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Tipi Guru in Gurubase, just let me know that's totally fine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Gurubase" badge in the README, linking to the Gurubase website.
	- Added a note highlighting that Tipi is built with TypeScript, Next.js app router, and Drizzle ORM, promoting collaboration via Discord.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->