### PR TITLE
feat: display tooltip on app tile description

### DIFF
--- a/packages/frontend/src/modules/app/components/store-tile/store-tile.tsx
+++ b/packages/frontend/src/modules/app/components/store-tile/store-tile.tsx
@@ -8,6 +8,8 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { colorSchemeForCategory } from '../../helpers/table-helpers';
 
+const DESCRIPTION_LENGTH_LIMIT = 30;
+
 export const StoreTile: React.FC<{ app: AppInfoSimple; isLoading: boolean }> = ({ app, isLoading }) => {
   const { t } = useTranslation();
 
@@ -28,8 +30,8 @@ export const StoreTile: React.FC<{ app: AppInfoSimple; isLoading: boolean }> = (
           </div>
           <p className="text-muted text-nowrap mb-2">
             <Skeleton loading={isLoading}>
-              <span title={app.short_desc.length > 30 ? app.short_desc : undefined}>
-                {limitText(app.short_desc, 30)}
+              <span title={app.short_desc.length > DESCRIPTION_LENGTH_LIMIT ? app.short_desc : undefined}>
+                {limitText(app.short_desc, DESCRIPTION_LENGTH_LIMIT)}
               </span>
             </Skeleton>
           </p>

--- a/packages/frontend/src/modules/app/components/store-tile/store-tile.tsx
+++ b/packages/frontend/src/modules/app/components/store-tile/store-tile.tsx
@@ -27,7 +27,11 @@ export const StoreTile: React.FC<{ app: AppInfoSimple; isLoading: boolean }> = (
             {isNew ? <div className="text-white badge me-1 bg-green">{t('APP_NEW')}</div> : null}
           </div>
           <p className="text-muted text-nowrap mb-2">
-            <Skeleton loading={isLoading}>{limitText(app.short_desc, 30)}</Skeleton>
+            <Skeleton loading={isLoading}>
+              <span title={app.short_desc.length > 30 ? app.short_desc : undefined}>
+                {limitText(app.short_desc, 30)}
+              </span>
+            </Skeleton>
           </p>
           {app.categories?.map((category) => (
             <Skeleton loading={isLoading} key={`${app.id}-${category}`}>


### PR DESCRIPTION
Display a native title/tooltip on hover in long app descriptions in the App Store:

![20241112_142050@2x](https://github.com/user-attachments/assets/7c4989d3-c1d6-40a7-bf5f-9d412cbe56c8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced accessibility of the short description in the StoreTile component with a tooltip for longer text.
- **Bug Fixes**
	- Improved loading behavior with the Skeleton component for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->