### PR TITLE
fix: include previous settings when writing settings file

### DIFF
--- a/packages/backend/src/core/filesystem/filesystem.service.ts
+++ b/packages/backend/src/core/filesystem/filesystem.service.ts
@@ -49,8 +49,7 @@ export class FilesystemService {
 
   async writeJsonFile<T>(filePath: string, data: T): Promise<boolean> {
     try {
-      await fs.promises.writeFile(filePath, JSON.stringify(data, null, 2), 'utf8');
-      await fs.promises.appendFile(filePath, EOL, 'utf8');
+      await fs.promises.writeFile(filePath, `${JSON.stringify(data, null, 2)}${EOL}`, 'utf8');
       return true;
     } catch (error) {
       this.logger.error(`Error writing file ${filePath}: ${error}`);
@@ -61,8 +60,7 @@ export class FilesystemService {
   async writeTextFile(filePath: string, content: string): Promise<boolean> {
     try {
       await fs.promises.mkdir(filePath.split('/').slice(0, -1).join('/'), { recursive: true });
-      await fs.promises.writeFile(filePath, content, 'utf8');
-      await fs.promises.appendFile(filePath, EOL, 'utf8');
+      await fs.promises.writeFile(filePath, `${content}${EOL}`, 'utf8');
       return true;
     } catch (error) {
       this.logger.error(`Error writing file ${filePath}: ${error}`);

--- a/packages/backend/src/core/filesystem/filesystem.service.ts
+++ b/packages/backend/src/core/filesystem/filesystem.service.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { LoggerService } from '@/core/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 import { ZodSchema } from 'zod';
+import { EOL } from 'node:os';
 
 @Injectable()
 export class FilesystemService {
@@ -49,6 +50,7 @@ export class FilesystemService {
   async writeJsonFile<T>(filePath: string, data: T): Promise<boolean> {
     try {
       await fs.promises.writeFile(filePath, JSON.stringify(data, null, 2), 'utf8');
+      await fs.promises.appendFile(filePath, EOL, 'utf8');
       return true;
     } catch (error) {
       this.logger.error(`Error writing file ${filePath}: ${error}`);
@@ -60,6 +62,7 @@ export class FilesystemService {
     try {
       await fs.promises.mkdir(filePath.split('/').slice(0, -1).join('/'), { recursive: true });
       await fs.promises.writeFile(filePath, content, 'utf8');
+      await fs.promises.appendFile(filePath, EOL, 'utf8');
       return true;
     } catch (error) {
       this.logger.error(`Error writing file ${filePath}: ${error}`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user settings management with improved file handling and validation.
	- Files written by the service now consistently end with a newline for better readability.

- **Bug Fixes**
	- Improved robustness in merging user settings to preserve existing configurations.

- **Chores**
	- Updated dependencies and import statements to reflect new functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->