### PR TITLE
fix(docker-builder): missing traefik labels for exposed app

### DIFF
--- a/packages/backend/src/modules/docker/builders/traefik-labels.builder.ts
+++ b/packages/backend/src/modules/docker/builders/traefik-labels.builder.ts
@@ -22,10 +22,12 @@ export class TraefikLabelsBuilder {
       Object.assign(this.labels, {
         'traefik.enable': true,
         [`traefik.http.routers.${this.params.appId}-insecure.rule`]: 'Host(`${APP_DOMAIN}`)',
+        [`traefik.http.routers.${this.params.appId}-insecure.entrypoints`]: 'web',
         [`traefik.http.routers.${this.params.appId}-insecure.service`]: this.params.appId,
         [`traefik.http.routers.${this.params.appId}-insecure.middlewares`]: `${this.params.appId}-web-redirect`,
         [`traefik.http.routers.${this.params.appId}.rule`]: 'Host(`${APP_DOMAIN}`)',
         [`traefik.http.routers.${this.params.appId}.entrypoints`]: 'websecure',
+        [`traefik.http.routers.${this.params.appId}.service`]: this.params.appId,
         [`traefik.http.routers.${this.params.appId}.tls.certresolver`]: 'myresolver',
       });
     }


### PR DESCRIPTION
This pull request includes changes to the `TraefikLabelsBuilder` class in the `traefik-labels.builder.ts` file to add new labels for Traefik routers. The most important changes include adding entry points and services for both insecure and secure routers.

Improvements to Traefik router labels:

* [`packages/backend/src/modules/docker/builders/traefik-labels.builder.ts`](diffhunk://#diff-c806014df12969b2736ba7d8eef249b42dceaf9294d82d7d6f6fc217714f738dR25-R30): Added `traefik.http.routers.${this.params.appId}-insecure.entrypoints` label with the value 'web'.
* [`packages/backend/src/modules/docker/builders/traefik-labels.builder.ts`](diffhunk://#diff-c806014df12969b2736ba7d8eef249b42dceaf9294d82d7d6f6fc217714f738dR25-R30): Added `traefik.http.routers.${this.params.appId}.service` label with the value of `this.params.appId`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced routing configuration with new entries for exposed and local labels in Traefik.
	- Added support for defining entry points and services for improved control flow in routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->