### PR TITLE
fix(docker-builder): missing traefik labels for exposed app

### DIFF
--- a/packages/backend/src/modules/docker/builders/traefik-labels.builder.ts
+++ b/packages/backend/src/modules/docker/builders/traefik-labels.builder.ts
@@ -22,10 +22,12 @@ export class TraefikLabelsBuilder {
       Object.assign(this.labels, {
         'traefik.enable': true,
         [`traefik.http.routers.${this.params.appId}-insecure.rule`]: 'Host(`${APP_DOMAIN}`)',
+        [`traefik.http.routers.${this.params.appId}-insecure.entrypoints`]: 'web',
         [`traefik.http.routers.${this.params.appId}-insecure.service`]: this.params.appId,
         [`traefik.http.routers.${this.params.appId}-insecure.middlewares`]: `${this.params.appId}-web-redirect`,
         [`traefik.http.routers.${this.params.appId}.rule`]: 'Host(`${APP_DOMAIN}`)',
         [`traefik.http.routers.${this.params.appId}.entrypoints`]: 'websecure',
+        [`traefik.http.routers.${this.params.appId}.service`]: this.params.appId,
         [`traefik.http.routers.${this.params.appId}.tls.certresolver`]: 'myresolver',
       });
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration for Traefik routers with updated entrypoints and service declarations for both insecure and secure routers.
	- Improved setup for local and exposed labels, ensuring accurate routing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->