### PR TITLE
Changed language selection cookie to expire from session to 365 days

### DIFF
--- a/packages/frontend/src/components/language-selector/language-selector.tsx
+++ b/packages/frontend/src/components/language-selector/language-selector.tsx
@@ -33,7 +33,7 @@ export const LanguageSelector = (props: IProps) => {
   const onChange = (newLocale: Locale) => {
     const locale = getLocaleFromString(newLocale);
     setLocale(newLocale);
-    Cookies.set('tipi-locale', locale);
+    Cookies.set('tipi-locale', locale, { expires: 365 });
     i18next.changeLanguage(locale);
   };
 


### PR DESCRIPTION
Fixes issue #1907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved language preference persistence by updating the cookie settings to retain your selected language for 365 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->