### PR TITLE
fix: disable local domain and auth when exposable is set to false

### DIFF
--- a/packages/frontend/src/modules/app/components/install-form/install-form.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form.tsx
@@ -154,50 +154,54 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
             <span className="text-muted">{t('APP_INSTALL_FORM_PORT_HINT')}</span>
           </div>
         )}
-        <Controller
-          control={control}
-          name="exposedLocal"
-          render={({ field: { onChange, value, ref, ...props } }) => (
-            <Switch
-              {...props}
-              className="mb-3"
-              ref={ref}
-              checked={value}
-              onCheckedChange={onChange}
-              label={
-                <>
-                  {t('APP_INSTALL_FORM_EXPOSE_LOCAL')}
-                  <Tooltip className="tooltip" anchorSelect=".enable-auth-hint">
-                    {t('APP_INSTALL_FORM_EXPOSE_LOCAL_HINT', { domain: localDomain, appId: info.id })}
-                  </Tooltip>
-                  <span className={clsx('ms-1 form-help enable-auth-hint')}>?</span>
-                </>
-              }
+        {info.exposable && (
+          <>
+            <Controller
+              control={control}
+              name="exposedLocal"
+              render={({ field: { onChange, value, ref, ...props } }) => (
+                <Switch
+                  {...props}
+                  className="mb-3"
+                  ref={ref}
+                  checked={value}
+                  onCheckedChange={onChange}
+                  label={
+                    <>
+                      {t('APP_INSTALL_FORM_EXPOSE_LOCAL')}
+                      <Tooltip className="tooltip" anchorSelect=".enable-auth-hint">
+                        {t('APP_INSTALL_FORM_EXPOSE_LOCAL_HINT', { domain: localDomain, appId: info.id })}
+                      </Tooltip>
+                      <span className={clsx('ms-1 form-help enable-auth-hint')}>?</span>
+                    </>
+                  }
+                />
+              )}
             />
-          )}
-        />
-        <Controller
-          control={control}
-          name="enableAuth"
-          render={({ field: { onChange, value, ref, ...props } }) => (
-            <Switch
-              {...props}
-              className="mb-3"
-              ref={ref}
-              checked={value}
-              onCheckedChange={onChange}
-              label={
-                <>
-                  {t('APP_INSTALL_FORM_ENABLE_AUTH')}
-                  <Tooltip className="tooltip" anchorSelect=".enable-auth-hint">
-                    {t('APP_INSTALL_FORM_ENABLE_AUTH_HINT')}
-                  </Tooltip>
-                  <span className={clsx('ms-1 form-help enable-auth-hint')}>?</span>
-                </>
-              }
+            <Controller
+              control={control}
+              name="enableAuth"
+              render={({ field: { onChange, value, ref, ...props } }) => (
+                <Switch
+                  {...props}
+                  className="mb-3"
+                  ref={ref}
+                  checked={value}
+                  onCheckedChange={onChange}
+                  label={
+                    <>
+                      {t('APP_INSTALL_FORM_ENABLE_AUTH')}
+                      <Tooltip className="tooltip" anchorSelect=".enable-auth-hint">
+                        {t('APP_INSTALL_FORM_ENABLE_AUTH_HINT')}
+                      </Tooltip>
+                      <span className={clsx('ms-1 form-help enable-auth-hint')}>?</span>
+                    </>
+                  }
+                />
+              )}
             />
-          )}
-        />
+          </>
+        )}
       </>
     );
   };

--- a/packages/frontend/src/modules/app/containers/app-actions/app-actions.tsx
+++ b/packages/frontend/src/modules/app/containers/app-actions/app-actions.tsx
@@ -166,7 +166,7 @@ export const AppActions = ({ app, info, localDomain, metadata }: IProps) => {
       break;
     case 'running':
       buttons.push(StopButton, restartButton, SettingsButton);
-      if (!info.no_gui) {
+      if (!info.no_gui && (app?.exposedLocal || app?.openPort || app?.exposed)) {
         buttons.push(OpenButton);
       }
       if (updateAvailable) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "exposedLocal" and "enableAuth" switches in the install form now appear only when applicable.
  - The "Open" button for running apps is shown only if the app has a GUI and is locally exposed, has an open port, or is exposed.

- **Refactor**
  - Streamlined visibility of form options and action buttons to enhance user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->