### PR TITLE
refactor: reset proxy settings if app is not exposable

### DIFF
--- a/packages/backend/src/modules/app-lifecycle/app-lifecycle.service.ts
+++ b/packages/backend/src/modules/app-lifecycle/app-lifecycle.service.ts
@@ -116,7 +116,7 @@ export class AppLifecycleService {
       parsedForm.exposed = false;
       parsedForm.exposedLocal = false;
       parsedForm.enableAuth = false;
-      parsedForm.domain = '';
+      parsedForm.domain = undefined;
     }
 
     if (appInfo.force_expose && !exposed) {
@@ -320,7 +320,7 @@ export class AppLifecycleService {
       parsedForm.exposed = false;
       parsedForm.exposedLocal = false;
       parsedForm.enableAuth = false;
-      parsedForm.domain = '';
+      parsedForm.domain = undefined;
     }
 
     if (appInfo.force_expose && !exposed) {

--- a/packages/backend/src/modules/app-lifecycle/app-lifecycle.service.ts
+++ b/packages/backend/src/modules/app-lifecycle/app-lifecycle.service.ts
@@ -109,8 +109,14 @@ export class AppLifecycleService {
       throw new TranslatableError('APP_ERROR_ARCHITECTURE_NOT_SUPPORTED', { id: appUrn, arch: architecture });
     }
 
-    if (!appInfo.exposable && exposed) {
-      throw new TranslatableError('APP_ERROR_APP_NOT_EXPOSABLE', { id: appUrn });
+    if (!appInfo.exposable) {
+      if (exposed || exposedLocal || enableAuth) {
+        this.logger.warn(`App ${appUrn} is not exposable, resetting proxy settings`);
+      }
+      parsedForm.exposed = false;
+      parsedForm.exposedLocal = false;
+      parsedForm.enableAuth = false;
+      parsedForm.domain = '';
     }
 
     if (appInfo.force_expose && !exposed) {
@@ -285,7 +291,7 @@ export class AppLifecycleService {
 
     const parsedForm = appFormSchema.parse(form);
 
-    const { exposed, domain } = parsedForm;
+    const { exposed, domain, exposedLocal, enableAuth } = parsedForm;
 
     if (exposed && !domain) {
       throw new TranslatableError('APP_ERROR_DOMAIN_REQUIRED_IF_EXPOSE_APP');
@@ -307,8 +313,14 @@ export class AppLifecycleService {
       throw new TranslatableError('APP_ERROR_APP_NOT_FOUND', { id: appUrn });
     }
 
-    if (!appInfo.exposable && exposed) {
-      throw new TranslatableError('APP_ERROR_APP_NOT_EXPOSABLE', { id: appUrn });
+    if (!appInfo.exposable) {
+      if (exposed || exposedLocal || enableAuth) {
+        this.logger.warn(`App ${appUrn} is not exposable, resetting proxy settings`);
+      }
+      parsedForm.exposed = false;
+      parsedForm.exposedLocal = false;
+      parsedForm.enableAuth = false;
+      parsedForm.domain = '';
     }
 
     if (appInfo.force_expose && !exposed) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of app exposure settings by automatically resetting exposure-related options for non-exposable apps during installation and configuration updates, preventing errors and ensuring consistent behavior.
  - Added warning logs when exposure settings are reset for non-exposable apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->