### PR TITLE
fix: disable traefik when app is not exposed

### DIFF
--- a/packages/backend/src/modules/docker/builders/__tests__/__snapshots__/compose.builder.test.ts.snap
+++ b/packages/backend/src/modules/docker/builders/__tests__/__snapshots__/compose.builder.test.ts.snap
@@ -65,11 +65,6 @@ exports[`DockerComposeBuilder > should be able to parse a compose.json file 1`] 
     depends_on:
       - ctfd-db
     labels:
-      generated: true
-      traefik.enable: false
-      traefik.docker.network: runtipi_tipi_main_network
-      traefik.http.middlewares.nginx-store-id-web-redirect.redirectscheme.scheme: https
-      traefik.http.services.nginx-store-id.loadbalancer.server.port: "8000"
       runtipi.managed: true
       some-label: some-value
       nginx-store-id.service: true

--- a/packages/backend/src/modules/docker/builders/compose.builder.ts
+++ b/packages/backend/src/modules/docker/builders/compose.builder.ts
@@ -101,7 +101,7 @@ export class DockerComposeBuilder {
         });
       }
 
-      if (params.internalPort && params.networkMode === undefined) {
+      if (params.internalPort && params.networkMode === undefined && (form.exposed || form.exposedLocal)) {
         const traefikLabels = new TraefikLabelsBuilder({
           storeId: appStoreId,
           appId: appName,

--- a/packages/backend/src/tests/integration/__snapshots__/app-lifecycle.test.ts.snap
+++ b/packages/backend/src/tests/integration/__snapshots__/app-lifecycle.test.ts.snap
@@ -72,11 +72,6 @@ exports[`App lifecycle > install app > should successfully install app and creat
     ports:
       - \${APP_PORT}:80
     labels:
-      generated: true
-      traefik.enable: false
-      traefik.docker.network: runtipi_tipi_main_network
-      traefik.http.middlewares.test-test-web-redirect.redirectscheme.scheme: https
-      traefik.http.services.test-test.loadbalancer.server.port: "80"
       runtipi.managed: true
 networks:
   tipi_main_network:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the conditions for adding Traefik labels to services, ensuring labels are only applied when specific exposure settings are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->