### PR TITLE
feat(guest-dashboard): download certificate button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ public/js/*
 /cache
 
 coverage
+docs/

--- a/packages/backend/src/modules/i18n/translations/en-US.json
+++ b/packages/backend/src/modules/i18n/translations/en-US.json
@@ -238,6 +238,7 @@
   "DELETE_BACKUP_MODAL_SUBTITLE": "This action cannot be undone",
   "DELETE_BACKUP_MODAL_SUBMIT": "Delete",
   "GUEST_DASHBOARD": "Guest dashboard",
+  "GUEST_DASHBOARD_DOWNLOAD_CERTIFICATE_TOOLTIP": "Download the self-signed certificate to securely access apps",
   "GUEST_DASHBOARD_NO_APPS": "No apps to display",
   "GUEST_DASHBOARD_NO_APPS_SUBTITLE": "Ask your administrator to add apps to the guest dashboard or login to see your apps.",
   "HEADER_APPS": "My Apps",
@@ -404,4 +405,3 @@
   "CLEAR": "Clear",
   "MORE": "More"
 }
-

--- a/packages/backend/src/modules/i18n/translations/en.json
+++ b/packages/backend/src/modules/i18n/translations/en.json
@@ -238,6 +238,7 @@
   "DELETE_BACKUP_MODAL_SUBTITLE": "This action cannot be undone",
   "DELETE_BACKUP_MODAL_SUBMIT": "Delete",
   "GUEST_DASHBOARD": "Guest dashboard",
+  "GUEST_DASHBOARD_DOWNLOAD_CERTIFICATE_TOOLTIP": "Download the self-signed certificate to securely access apps",
   "GUEST_DASHBOARD_NO_APPS": "No apps to display",
   "GUEST_DASHBOARD_NO_APPS_SUBTITLE": "Ask your administrator to add apps to the guest dashboard or login to see your apps.",
   "HEADER_APPS": "My Apps",
@@ -404,4 +405,3 @@
   "CLEAR": "Clear",
   "MORE": "More"
 }
-

--- a/packages/backend/src/modules/system/system.controller.ts
+++ b/packages/backend/src/modules/system/system.controller.ts
@@ -5,11 +5,11 @@ import { AuthGuard } from '../auth/auth.guard';
 import { LoadDto } from './dto/system.dto';
 import { SystemService } from './system.service';
 
-@UseGuards(AuthGuard)
 @Controller('system')
 export class SystemController {
   constructor(private readonly systemService: SystemService) {}
 
+  @UseGuards(AuthGuard)
   @Get('/load')
   @ZodSerializerDto(LoadDto)
   async systemLoad(): Promise<LoadDto> {

--- a/packages/frontend/src/components/header/guest-header.tsx
+++ b/packages/frontend/src/components/header/guest-header.tsx
@@ -1,6 +1,6 @@
 import { getLogo } from '@/lib/theme/theme';
 import { useUIStore } from '@/stores/ui-store';
-import { IconBrandGithub, IconHeart, IconLogin, IconMoon, IconSun } from '@tabler/icons-react';
+import { IconBrandGithub, IconCertificate, IconHeart, IconLogin, IconMoon, IconSun } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
 import { Tooltip } from 'react-tooltip';
@@ -11,6 +11,10 @@ export const GuestHeader = () => {
   const { t } = useTranslation();
 
   const navigate = useNavigate();
+
+  const downloadCertificate = () => {
+    window.open('/api/system/certificate');
+  };
 
   return (
     <header className="text-white navbar navbar-expand-md navbar-dark navbar-overlap d-print-none" data-bs-theme="dark">
@@ -46,6 +50,17 @@ export const GuestHeader = () => {
             </div>
           </div>
           <div style={{ zIndex: 1 }} className="d-flex">
+            <Tooltip className="tooltip" anchorSelect=".downloadCert">
+              {t('GUEST_DASHBOARD_DOWNLOAD_CERTIFICATE_TOOLTIP')}
+            </Tooltip>
+            <button
+              type="button"
+              onClick={downloadCertificate}
+              className="downloadCert nav-link px-0 cursor-pointer"
+              data-testid="download-certificate-button"
+            >
+              <IconCertificate size={20} />
+            </button>
             <Tooltip className="tooltip" anchorSelect=".darkMode">
               {t('HEADER_DARK_MODE')}
             </Tooltip>


### PR DESCRIPTION
Closes #1822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a button to the guest header allowing users to download a certificate, complete with an icon and localized tooltip.

- **Localization**
	- Introduced a new translation string for the certificate download tooltip in English.

- **Chores**
	- Updated the `.gitignore` file to exclude the `docs/` directory from version control.

- **Refactor**
	- Adjusted authentication guard placement on system endpoints, limiting protection to the `/load` endpoint only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->