### PR TITLE
fix(install.sh): update RPM-based package manager commands

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,6 +113,7 @@ function install_docker() {
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
     return 0
   elif [[ "${os}" == "centos" || "${os}" == "rocky" ]]; then # accurate as of Rocky Linux 9 and CentOS Stream 10 as they still use DNF4
+    sudo dnf4 -y install dnf-plugins-core
     sudo dnf4 config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
     sudo dnf4 -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     sudo systemctl start docker

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,23 +112,16 @@ function install_docker() {
     sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
     return 0
-  elif [[ "${os}" == "centos" ]]; then
-    sudo yum install -y yum-utils
-    sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-    sudo yum install -y --allowerasing docker-ce docker-ce-cli containerd.io docker-compose-plugin
-    sudo systemctl start docker
-    sudo systemctl enable docker
-    return 0
-  elif [[ "${os}" == "rocky" ]]; then
-    sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-    sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+  elif [[ "${os}" == "centos" || "${os}" == "rocky" ]]; then # accurate as of Rocky Linux 9 and CentOS Stream 10 as they still use DNF4
+    sudo dnf4 config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    sudo dnf4 -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     sudo systemctl start docker
     sudo systemctl enable docker
     return 0
   elif [[ "${os}" == "fedora" ]]; then
-    sudo dnf -y install dnf-plugins-core
-    sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
-    sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    sudo dnf5 -y install dnf5-plugins
+    sudo dnf5 config-manager addrepo --from-repofile="https://download.docker.com/linux/fedora/docker-ce.repo"
+    sudo dnf5 -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     sudo systemctl start docker
     sudo systemctl enable docker
     return 0


### PR DESCRIPTION
Fixes #2153; I have confirmed this fix to work on Fedora 42.

* Updated Fedora commands to dnf5 (in use from Fedora 40 onwards; 39 has passed EOL)

Based on my knowledge of the ecosystem, I made two more adjustments. I have not tested these and I am basing them on assumptions:

* Removed CentOS-specific instructions that used yum, as they were only valid up to CentOS 7, which reached EOL in 2024-06-30
* Combined Rocky Linux and CentOS (now called CentOS Stream) entries, which continue to use dnf4 in their current releases (Rocky Linux 9, CentOS Stream 10). The should continue to work if they upgrade to dnf5 and the user updates their distribution.
* Made the dnf4 command explicit

I am basing the CentOS update on the assumption that CentOS Stream continues to report itself as "`centos`", and that grep would pick it up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Docker installation process to use the latest package managers for CentOS, Rocky Linux, and Fedora.
	- Streamlined installation steps for improved compatibility with newer OS versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->