### PR TITLE
fix(auth): support trusted proxy IPs for forwarded headers

### DIFF
--- a/packages/backend/assets/traefik/traefik.yml
+++ b/packages/backend/assets/traefik/traefik.yml
@@ -14,8 +14,24 @@ providers:
 entryPoints:
   web:
     address: ":80"
+    forwardedHeaders:
+      trustedIPs:
+        - "127.0.0.1/32"
+        - "10.0.0.0/8"
+        - "172.16.0.0/12"
+        - "192.168.0.0/16"
+        - "::1/128"
+        - "fc00::/7"
   websecure:
     address: ":443"
+    forwardedHeaders:
+      trustedIPs:
+        - "127.0.0.1/32"
+        - "10.0.0.0/8"
+        - "172.16.0.0/12"
+        - "192.168.0.0/16"
+        - "::1/128"
+        - "fc00::/7"
     http:
       tls:
         certResolver: myresolver

--- a/packages/backend/src/__tests__/app.service.test.ts
+++ b/packages/backend/src/__tests__/app.service.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { AppService } from '@/app.service';
 import { APP_DATA_DIR, APP_DIR, DATA_DIR } from '@/common/constants';
 import { ConfigurationService } from '@/core/config/configuration.service';
@@ -11,6 +12,28 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 import { DOCKERODE } from '@/modules/docker/docker.module';
+import YAML from 'yaml';
+
+const TRAEFIK_CONFIG = `api:
+  dashboard: true
+  insecure: true
+
+entryPoints:
+  web:
+    address: ":80"
+    forwardedHeaders:
+      insecure: true
+      trustedIPs:
+        - "127.0.0.1/32"
+  websecure:
+    address: ":443"
+    forwardedHeaders:
+      trustedIPs:
+        - "127.0.0.1/32"
+    http:
+      tls:
+        certResolver: myresolver
+`;
 
 describe('AppService', () => {
   let appService: AppService;
@@ -142,6 +165,30 @@ describe('AppService', () => {
 
       // assert
       expect((fs as unknown as FsMock).tree()).toMatchSnapshot();
+    });
+
+    it('should append extra trusted proxy IPs to traefik config', async () => {
+      const appDir = APP_DIR;
+      const dataDir = DATA_DIR;
+      const appDataDir = APP_DATA_DIR;
+      const directories = { appDir, dataDir, appDataDir };
+      const fsMock = fs as unknown as FsMock;
+      fsMock.__applyMockFiles({
+        [path.join(APP_DIR, 'assets', 'traefik', 'traefik.yml')]: TRAEFIK_CONFIG,
+        [path.join(APP_DIR, 'assets', 'traefik', 'dynamic', 'dynamic.yml')]: '',
+      });
+      configurationService.getConfig.mockReturnValueOnce(fromPartial({ directories, userSettings: { persistTraefikConfig: false } }));
+      configurationService.get.calledWith('traefik').mockReturnValueOnce({
+        trustedProxyIps: ['203.0.113.10/32', '2001:db8::/32', '203.0.113.10/32'],
+      });
+
+      await appService.copyAssets();
+
+      const output = await fs.promises.readFile(path.join(DATA_DIR, 'traefik', 'traefik.yml'), 'utf8');
+      const parsed = YAML.parse(output);
+      expect(parsed.entryPoints.web.forwardedHeaders.insecure).toBe(true);
+      expect(parsed.entryPoints.web.forwardedHeaders.trustedIPs).toEqual(['127.0.0.1/32', '203.0.113.10/32', '2001:db8::/32']);
+      expect(parsed.entryPoints.websecure.forwardedHeaders.trustedIPs).toEqual(['127.0.0.1/32', '203.0.113.10/32', '2001:db8::/32']);
     });
   });
 });

--- a/packages/backend/src/app.dto.ts
+++ b/packages/backend/src/app.dto.ts
@@ -31,6 +31,7 @@ export const settingsSchema = type({
   experimental_insecureCookie: 'boolean?',
   themeBase: 'string?',
   themeColor: 'string?',
+  trustedProxyIps: 'string.trim?',
 });
 
 const versionSchema = type({

--- a/packages/backend/src/app.service.ts
+++ b/packages/backend/src/app.service.ts
@@ -15,6 +15,7 @@ import { SystemEventsQueue } from './modules/queue/entities/system-events';
 import { DOCKERODE } from './modules/docker/docker.module';
 import Dockerode from 'dockerode';
 import { GithubService } from './utils/github/github.service';
+import YAML from 'yaml';
 
 @Injectable()
 export class AppService {
@@ -114,7 +115,7 @@ export class AppService {
       this.logger.warn('Skipping the copy of traefik files because persistTraefikConfig is set to true');
     } else {
       this.logger.info('Copying traefik files');
-      await this.filesystem.copyFile(path.join(assetsFolder, 'traefik', 'traefik.yml'), path.join(dataDir, 'traefik', 'traefik.yml'));
+      await this.writeTraefikConfig(path.join(assetsFolder, 'traefik', 'traefik.yml'), path.join(dataDir, 'traefik', 'traefik.yml'));
       await this.filesystem.copyFile(
         path.join(assetsFolder, 'traefik', 'dynamic', 'dynamic.yml'),
         path.join(dataDir, 'traefik', 'dynamic', 'dynamic.yml'),
@@ -152,6 +153,37 @@ export class AppService {
       path.join(dataDir, 'media', 'data', 'images'),
       path.join(dataDir, 'media', 'data', 'roms'),
     ]);
+  }
+
+  private async writeTraefikConfig(src: string, dest: string) {
+    const config = await this.filesystem.readTextFile(src);
+    if (!config) {
+      await this.filesystem.copyFile(src, dest);
+      return;
+    }
+
+    const parsed = YAML.parse(config) as {
+      entryPoints?: Record<string, { forwardedHeaders?: unknown }>;
+    };
+    const { trustedProxyIps } = this.configuration.get('traefik');
+
+    for (const entrypoint of ['web', 'websecure']) {
+      parsed.entryPoints ??= {};
+      parsed.entryPoints[entrypoint] ??= {};
+
+      const currentForwardedHeaders = parsed.entryPoints[entrypoint].forwardedHeaders;
+      if (!currentForwardedHeaders || typeof currentForwardedHeaders !== 'object' || Array.isArray(currentForwardedHeaders)) {
+        parsed.entryPoints[entrypoint].forwardedHeaders = {};
+      }
+
+      const forwardedHeaders = parsed.entryPoints[entrypoint].forwardedHeaders as { trustedIPs?: string[] } & Record<string, unknown>;
+      const currentTrustedIps = forwardedHeaders.trustedIPs ?? [];
+      const trustedIPs = [...new Set([...currentTrustedIps, ...trustedProxyIps])];
+
+      forwardedHeaders.trustedIPs = trustedIPs;
+    }
+
+    await this.filesystem.writeTextFile(dest, YAML.stringify(parsed));
   }
 
   /**

--- a/packages/backend/src/common/helpers/env-helpers.ts
+++ b/packages/backend/src/common/helpers/env-helpers.ts
@@ -135,6 +135,10 @@ export const generateSystemEnvFile = async (): Promise<Map<string, string>> => {
     typeof settings.persistTraefikConfig === 'boolean' ? String(settings.persistTraefikConfig) : envMap.get('PERSIST_TRAEFIK_CONFIG') || 'false',
   );
   envMap.set(
+    'RUNTIPI_TRUSTED_PROXY_IPS',
+    typeof settings.trustedProxyIps === 'string' ? settings.trustedProxyIps : envMap.get('RUNTIPI_TRUSTED_PROXY_IPS') || '',
+  );
+  envMap.set(
     'QUEUE_TIMEOUT_IN_MINUTES',
     typeof settings.eventsTimeout === 'number' ? String(settings.eventsTimeout) : envMap.get('QUEUE_TIMEOUT_IN_MINUTES') || '5',
   );

--- a/packages/backend/src/core/config/configuration.service.test.ts
+++ b/packages/backend/src/core/config/configuration.service.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { isValidIpOrCidr, parseTrustedProxyIps } from './configuration.service';
+
+describe('isValidIpOrCidr', () => {
+  it('accepts valid IPv4 and IPv6 addresses', () => {
+    expect(isValidIpOrCidr('192.0.2.10')).toBe(true);
+    expect(isValidIpOrCidr('2001:db8::1')).toBe(true);
+  });
+
+  it('accepts valid IPv4 and IPv6 CIDR ranges', () => {
+    expect(isValidIpOrCidr('192.0.2.0/24')).toBe(true);
+    expect(isValidIpOrCidr('2001:db8::/32')).toBe(true);
+    expect(isValidIpOrCidr('0.0.0.0/0')).toBe(true);
+    expect(isValidIpOrCidr('::/0')).toBe(true);
+  });
+
+  it('rejects malformed addresses and invalid CIDR prefixes', () => {
+    expect(isValidIpOrCidr('192.0.2.999')).toBe(false);
+    expect(isValidIpOrCidr('192.0.2.0/33')).toBe(false);
+    expect(isValidIpOrCidr('2001:db8::/129')).toBe(false);
+    expect(isValidIpOrCidr('2001:db8::/abc')).toBe(false);
+    expect(isValidIpOrCidr('192.0.2.0/24/extra')).toBe(false);
+  });
+});
+
+describe('parseTrustedProxyIps', () => {
+  it('trims tokens and returns only valid IPs and CIDRs', () => {
+    const result = parseTrustedProxyIps(' 192.0.2.10 , invalid , 2001:db8::/32, 192.0.2.0/33, , ::1 ');
+
+    expect(result.trustedProxyIps).toEqual(['192.0.2.10', '2001:db8::/32', '::1']);
+    expect(result.invalidProxyIps).toEqual(['invalid', '192.0.2.0/33']);
+  });
+});

--- a/packages/backend/src/core/config/configuration.service.ts
+++ b/packages/backend/src/core/config/configuration.service.ts
@@ -8,6 +8,7 @@ import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import * as Sentry from '@sentry/nestjs';
 import { type } from 'arktype';
 import dotenv from 'dotenv';
+import validator from 'validator';
 import { LOG_LEVEL_ENUM, type LogLevel, LoggerService } from '../logger/logger.service';
 
 const envSchema = type({
@@ -35,6 +36,7 @@ const envSchema = type({
   ALLOW_ERROR_MONITORING: 'string',
   ALLOW_AUTO_THEMES: 'string',
   PERSIST_TRAEFIK_CONFIG: 'string',
+  RUNTIPI_TRUSTED_PROXY_IPS: 'string = ""',
   QUEUE_TIMEOUT_IN_MINUTES: type('number | string.numeric.parse').default(5),
   LOG_LEVEL: 'string = "info"',
   TZ: 'string',
@@ -48,6 +50,30 @@ const envSchema = type({
   // Experimental flags
   EXPERIMENTAL_INSECURE_COOKIE: 'string',
 });
+
+export const isValidIpOrCidr = (value: string) => {
+  return validator.isIP(value) || validator.isIPRange(value);
+};
+
+export const parseTrustedProxyIps = (value: string) => {
+  const trustedProxyIps: string[] = [];
+  const invalidProxyIps: string[] = [];
+
+  for (const token of value.split(',')) {
+    const trimmedToken = token.trim();
+    if (!trimmedToken) {
+      continue;
+    }
+
+    if (isValidIpOrCidr(trimmedToken)) {
+      trustedProxyIps.push(trimmedToken);
+    } else {
+      invalidProxyIps.push(trimmedToken);
+    }
+  }
+
+  return { trustedProxyIps, invalidProxyIps };
+};
 
 @Injectable()
 export class ConfigurationService {
@@ -87,6 +113,10 @@ export class ConfigurationService {
     this.logger = new LoggerService('backend', path.join(DATA_DIR, 'logs'), logLevel);
 
     const { NODE_ENV } = process.env;
+    const { trustedProxyIps, invalidProxyIps } = parseTrustedProxyIps(env.RUNTIPI_TRUSTED_PROXY_IPS);
+    if (invalidProxyIps.length) {
+      this.logger.warn('Dropped invalid RUNTIPI_TRUSTED_PROXY_IPS entries', invalidProxyIps);
+    }
 
     return {
       database: {
@@ -136,6 +166,9 @@ export class ConfigurationService {
         experimental: {
           insecureCookie: env.EXPERIMENTAL_INSECURE_COOKIE.toLowerCase() === 'true',
         },
+      },
+      traefik: {
+        trustedProxyIps,
       },
       deprecatedAppsRepoId: env.APPS_REPO_ID, // @deprecated
       deprecatedAppsRepoUrl: env.APPS_REPO_URL, // @deprecated


### PR DESCRIPTION
Trust internal CIDR by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring trusted proxy IPs for Traefik; applied to both web and websecure forwarded headers.
  * Trusted-proxy values can be supplied via environment/system config and are persisted to generated env output.
  * Input values are parsed and validated; invalid entries are ignored and logged as warnings.

* **Tests**
  * Added unit tests covering validation/parsing of proxy IPs and the Traefik config update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->