### PR TITLE
Correct typo in app data path hint

### DIFF
--- a/packages/backend/src/modules/i18n/translations/af-ZA.json
+++ b/packages/backend/src/modules/i18n/translations/af-ZA.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/ar-SA.json
+++ b/packages/backend/src/modules/i18n/translations/ar-SA.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/ca-ES.json
+++ b/packages/backend/src/modules/i18n/translations/ca-ES.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/cs-CZ.json
+++ b/packages/backend/src/modules/i18n/translations/cs-CZ.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/da-DK.json
+++ b/packages/backend/src/modules/i18n/translations/da-DK.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/de-DE.json
+++ b/packages/backend/src/modules/i18n/translations/de-DE.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/en-US.json
+++ b/packages/backend/src/modules/i18n/translations/en-US.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/en.json
+++ b/packages/backend/src/modules/i18n/translations/en.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/es-ES.json
+++ b/packages/backend/src/modules/i18n/translations/es-ES.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/fi-FI.json
+++ b/packages/backend/src/modules/i18n/translations/fi-FI.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/he-IL.json
+++ b/packages/backend/src/modules/i18n/translations/he-IL.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/ja-JP.json
+++ b/packages/backend/src/modules/i18n/translations/ja-JP.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/ko-KR.json
+++ b/packages/backend/src/modules/i18n/translations/ko-KR.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/nl-NL.json
+++ b/packages/backend/src/modules/i18n/translations/nl-NL.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/no-NO.json
+++ b/packages/backend/src/modules/i18n/translations/no-NO.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/pt-PT.json
+++ b/packages/backend/src/modules/i18n/translations/pt-PT.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/ro-RO.json
+++ b/packages/backend/src/modules/i18n/translations/ro-RO.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/sr-SP.json
+++ b/packages/backend/src/modules/i18n/translations/sr-SP.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/vi-VN.json
+++ b/packages/backend/src/modules/i18n/translations/vi-VN.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",

--- a/packages/backend/src/modules/i18n/translations/zh-TW.json
+++ b/packages/backend/src/modules/i18n/translations/zh-TW.json
@@ -513,7 +513,7 @@
   "SETTINGS_GENERAL_SETTINGS_UPDATED_RESTART": "Settings updated. Restart your instance to apply new settings.",
   "SETTINGS_GENERAL_SETTINGS_UPDATED": "Settings updated.",
   "SETTINGS_GENERAL_APP_DATA_PATH": "App data path",
-  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are storred.",
+  "SETTINGS_GENERAL_APP_DATA_PATH_HINT": "The location in which app data are stored.",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG": "Persist Traefik config",
   "SETTINGS_GENERAL_PERSIST_TRAEFIK_CONFIG_HINT": "Persist the Traefik configuration folder throughout restarts. This will allow you to customize the Traefik configuration.",
   "SETTINGS_GENERAL_DOMAIN": "Domain name",


### PR DESCRIPTION
Correct "storred" to "stored" in all applicable translation files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a spelling error in the app data path hint message across all supported language translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runtipi/runtipi/pull/2605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->