### PR TITLE
fix: harden backup restore against unsafe symlinks

### DIFF
--- a/packages/backend/src/modules/backups/__tests__/backup.manager.security.test.ts
+++ b/packages/backend/src/modules/backups/__tests__/backup.manager.security.test.ts
@@ -1,13 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { DATA_DIR } from '@/common/constants';
+import { createAppUrn } from '@/common/helpers/app-helpers';
 import type { ArchiveService } from '@/core/archive/archive.service';
 import type { ConfigurationService } from '@/core/config/configuration.service';
 import { FilesystemService } from '@/core/filesystem/filesystem.service';
 import type { LoggerService } from '@/core/logger/logger.service';
 import type { AppFilesManager } from '@/modules/apps/app-files-manager';
 import type { AppUrn } from '@runtipi/common/types';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BackupManager } from '../backup.manager';
 
 const writeFile = async (filePath: string, content: string) => {
@@ -15,16 +16,19 @@ const writeFile = async (filePath: string, content: string) => {
   await fs.promises.writeFile(filePath, content);
 };
 
+const createLogger = () =>
+  ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }) as unknown as LoggerService;
+
 describe('BackupManager file security', () => {
   let manager: BackupManager;
 
   beforeEach(() => {
-    const logger = {
-      debug: vi.fn(),
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-    } as unknown as LoggerService;
+    const logger = createLogger();
 
     const config = {
       get: vi.fn().mockReturnValue({ dataDir: DATA_DIR }),
@@ -46,5 +50,127 @@ describe('BackupManager file security', () => {
     await writeFile(backupPath, 'backup');
 
     await expect(manager.getBackupPath('demo:store' as AppUrn, 'demo-store-1.tar.gz')).resolves.toBe(backupPath);
+  });
+});
+
+describe('BackupManager restore security', () => {
+  const appUrn = createAppUrn('test-app', 'test-store');
+
+  let rootDir: string;
+  let dataDir: string;
+  let restoreDir: string;
+  let appDataDir: string;
+  let appInstalledDir: string;
+  let userConfigDir: string;
+  let archivePath: string;
+  let backupManager: BackupManager;
+  let extractTarGz: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    await fs.promises.mkdir('/tmp', { recursive: true });
+    rootDir = await fs.promises.mkdtemp('/tmp/runtipi-backup-test-');
+    dataDir = path.join(rootDir, 'data');
+    restoreDir = path.join(rootDir, 'restore');
+    appDataDir = path.join(rootDir, 'app-data', 'test-store', 'test-app');
+    appInstalledDir = path.join(rootDir, 'apps', 'test-store', 'test-app');
+    userConfigDir = path.join(dataDir, 'user-config', 'test-store', 'test-app');
+    archivePath = path.join(dataDir, 'backups', 'test-store', 'test-app', 'backup.tar.gz');
+
+    const logger = createLogger();
+    const filesystem = new FilesystemService(logger);
+    extractTarGz = vi.fn();
+
+    const archiveManager = {
+      extractTarGz,
+    } as unknown as ArchiveService;
+
+    const config = {
+      get: vi.fn().mockReturnValue({ dataDir, appDataDir: path.join(rootDir, 'app-data'), appDir: path.join(rootDir, 'apps') }),
+    } as unknown as ConfigurationService;
+
+    const appFilesManager = {
+      getAppPaths: vi.fn().mockReturnValue({ appDataDir, appInstalledDir }),
+    } as unknown as AppFilesManager;
+
+    vi.spyOn(filesystem, 'createTempDirectory').mockResolvedValue(restoreDir);
+
+    await fs.promises.mkdir(path.dirname(archivePath), { recursive: true });
+    await fs.promises.writeFile(archivePath, '');
+    await fs.promises.mkdir(appDataDir, { recursive: true });
+    await fs.promises.mkdir(appInstalledDir, { recursive: true });
+    await fs.promises.mkdir(userConfigDir, { recursive: true });
+    await fs.promises.writeFile(path.join(userConfigDir, 'app.env'), 'EXISTING=true\n');
+
+    backupManager = new BackupManager(archiveManager, logger, config, filesystem, appFilesManager);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (rootDir) {
+      await fs.promises.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects restored backups containing symlinks before replacing live files', async () => {
+    const targetFile = path.join(dataDir, 'state', 'proof.txt');
+    await fs.promises.mkdir(path.dirname(targetFile), { recursive: true });
+    await fs.promises.writeFile(targetFile, 'unchanged\n');
+
+    extractTarGz.mockImplementation(async (_archive: string, destinationDir: string) => {
+      await fs.promises.mkdir(path.join(destinationDir, 'app-data'), { recursive: true });
+      await fs.promises.mkdir(path.join(destinationDir, 'app'), { recursive: true });
+      await fs.promises.mkdir(path.join(destinationDir, 'user-config'), { recursive: true });
+      await fs.promises.symlink(targetFile, path.join(destinationDir, 'user-config', 'app.env'));
+
+      return { stdout: '', stderr: '' };
+    });
+
+    await expect(backupManager.restoreApp(appUrn, 'backup.tar.gz')).rejects.toThrow('Backup contains unsupported file types');
+
+    await expect(fs.promises.readFile(path.join(userConfigDir, 'app.env'), 'utf8')).resolves.toBe('EXISTING=true\n');
+    await expect(fs.promises.readFile(targetFile, 'utf8')).resolves.toBe('unchanged\n');
+  });
+
+  it('rejects restored app-data symlinks that point outside app-data', async () => {
+    const targetFile = path.join(dataDir, 'state', 'proof.txt');
+    const liveFile = path.join(appDataDir, 'data', 'live.txt');
+    await fs.promises.mkdir(path.dirname(targetFile), { recursive: true });
+    await fs.promises.mkdir(path.dirname(liveFile), { recursive: true });
+    await fs.promises.writeFile(targetFile, 'unchanged\n');
+    await fs.promises.writeFile(liveFile, 'live data\n');
+
+    extractTarGz.mockImplementation(async (_archive: string, destinationDir: string) => {
+      await fs.promises.mkdir(path.join(destinationDir, 'app-data'), { recursive: true });
+      await fs.promises.mkdir(path.join(destinationDir, 'app'), { recursive: true });
+      await fs.promises.symlink(targetFile, path.join(destinationDir, 'app-data', 'proof.txt'));
+
+      return { stdout: '', stderr: '' };
+    });
+
+    await expect(backupManager.restoreApp(appUrn, 'backup.tar.gz')).rejects.toThrow('Backup contains unsupported file types');
+
+    await expect(fs.promises.readFile(liveFile, 'utf8')).resolves.toBe('live data\n');
+    await expect(fs.promises.readFile(targetFile, 'utf8')).resolves.toBe('unchanged\n');
+  });
+
+  it('restores backups containing regular files and directories', async () => {
+    extractTarGz.mockImplementation(async (_archive: string, destinationDir: string) => {
+      await fs.promises.mkdir(path.join(destinationDir, 'app-data', 'data'), { recursive: true });
+      await fs.promises.mkdir(path.join(destinationDir, 'app'), { recursive: true });
+      await fs.promises.mkdir(path.join(destinationDir, 'user-config'), { recursive: true });
+      await fs.promises.writeFile(path.join(destinationDir, 'app-data', 'data', 'file.txt'), 'restored data\n');
+      await fs.promises.symlink('data/file.txt', path.join(destinationDir, 'app-data', 'file-link.txt'));
+      await fs.promises.writeFile(path.join(destinationDir, 'app', 'docker-compose.yml'), 'services: {}\n');
+      await fs.promises.writeFile(path.join(destinationDir, 'user-config', 'app.env'), 'RESTORED=true\n');
+
+      return { stdout: '', stderr: '' };
+    });
+
+    await backupManager.restoreApp(appUrn, 'backup.tar.gz');
+
+    await expect(fs.promises.readFile(path.join(appDataDir, 'data', 'file.txt'), 'utf8')).resolves.toBe('restored data\n');
+    await expect(fs.promises.readFile(path.join(appDataDir, 'file-link.txt'), 'utf8')).resolves.toBe('restored data\n');
+    await expect(fs.promises.readFile(path.join(appInstalledDir, 'docker-compose.yml'), 'utf8')).resolves.toBe('services: {}\n');
+    await expect(fs.promises.readFile(path.join(userConfigDir, 'app.env'), 'utf8')).resolves.toBe('RESTORED=true\n');
   });
 });

--- a/packages/backend/src/modules/backups/backup.manager.ts
+++ b/packages/backend/src/modules/backups/backup.manager.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { extractAppUrn } from '@/common/helpers/app-helpers';
-import { sanitizeFilename } from '@/common/helpers/file-helpers';
+import { pLimit, sanitizeFilename } from '@/common/helpers/file-helpers';
 import { ArchiveService } from '@/core/archive/archive.service';
 import { ConfigurationService } from '@/core/config/configuration.service';
 import { FilesystemService } from '@/core/filesystem/filesystem.service';
@@ -132,13 +132,25 @@ export class BackupManager {
       this.logger.debug('stderr:', stderr);
       this.logger.debug('stdout:', stdout);
 
-      await this.validateRestoreDirectory(path.join(restoreDir, 'app-data'), { allowSymlinks: true });
-      await this.validateRestoreDirectory(path.join(restoreDir, 'app'), { allowSymlinks: true, rejectHardLinks: true });
-      await this.validateRestoreDirectory(path.join(restoreDir, 'user-config'), {
-        allowSymlinks: false,
-        optional: true,
-        rejectHardLinks: true,
-      });
+      const runValidationFsOperation = pLimit(16);
+
+      await this.validateRestoreDirectory(path.join(restoreDir, 'app-data'), { allowSymlinks: true }, undefined, runValidationFsOperation);
+      await this.validateRestoreDirectory(
+        path.join(restoreDir, 'app'),
+        { allowSymlinks: true, rejectHardLinks: true },
+        undefined,
+        runValidationFsOperation,
+      );
+      await this.validateRestoreDirectory(
+        path.join(restoreDir, 'user-config'),
+        {
+          allowSymlinks: false,
+          optional: true,
+          rejectHardLinks: true,
+        },
+        undefined,
+        runValidationFsOperation,
+      );
 
       const { appInstalledDir, appDataDir } = this.appFilesManager.getAppPaths(appUrn);
 
@@ -167,8 +179,9 @@ export class BackupManager {
     directory: string,
     options: { allowSymlinks: boolean; optional?: boolean; rejectHardLinks?: boolean },
     rootDirectory = directory,
-  ): Promise<void> {
-    const directoryStats = await fs.promises.lstat(directory).catch((error: NodeJS.ErrnoException) => {
+    runFsOperation = pLimit(16),
+  ) {
+    const directoryStats = await runFsOperation(() => fs.promises.lstat(directory)).catch((error: NodeJS.ErrnoException) => {
       if (options.optional && error.code === 'ENOENT') {
         return null;
       }
@@ -184,11 +197,19 @@ export class BackupManager {
       throw new Error('Backup contains unsupported file types');
     }
 
-    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+    const entries = await runFsOperation(() => fs.promises.readdir(directory, { withFileTypes: true }));
     const rootPath = path.resolve(rootDirectory);
+    let nextEntryIndex = 0;
 
-    await Promise.all(
-      entries.map(async (entry) => {
+    const workers = Array.from({ length: Math.min(16, entries.length) }, async () => {
+      while (nextEntryIndex < entries.length) {
+        const entry = entries[nextEntryIndex];
+        nextEntryIndex += 1;
+
+        if (!entry) {
+          continue;
+        }
+
         const entryPath = path.join(directory, entry.name);
 
         if (entry.isSymbolicLink()) {
@@ -196,36 +217,38 @@ export class BackupManager {
             throw new Error('Backup contains unsupported file types');
           }
 
-          const linkTarget = await fs.promises.readlink(entryPath);
+          const linkTarget = await runFsOperation(() => fs.promises.readlink(entryPath));
           const resolvedTarget = path.resolve(path.dirname(entryPath), linkTarget);
 
           if (!this.isPathInsideOrEqual(rootPath, resolvedTarget)) {
             throw new Error('Backup contains unsupported file types');
           }
 
-          return;
+          continue;
         }
 
         if (entry.isDirectory()) {
-          await this.validateRestoreDirectory(entryPath, options, rootDirectory);
-          return;
+          await this.validateRestoreDirectory(entryPath, options, rootDirectory, runFsOperation);
+          continue;
         }
 
         if (entry.isFile()) {
           if (options.rejectHardLinks) {
-            const stats = await fs.promises.lstat(entryPath);
+            const stats = await runFsOperation(() => fs.promises.lstat(entryPath));
 
             if (stats.nlink > 1) {
               throw new Error('Backup contains unsupported file types');
             }
           }
 
-          return;
+          continue;
         }
 
         throw new Error('Backup contains unsupported file types');
-      }),
-    );
+      }
+    });
+
+    await Promise.all(workers);
   }
 
   private isPathInsideOrEqual(parentPath: string, childPath: string): boolean {

--- a/packages/backend/src/modules/backups/backup.manager.ts
+++ b/packages/backend/src/modules/backups/backup.manager.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { extractAppUrn } from '@/common/helpers/app-helpers';
 import { sanitizeFilename } from '@/common/helpers/file-helpers';
@@ -124,34 +125,114 @@ export class BackupManager {
     // Unzip the archive
     await this.filesystem.createDirectory(restoreDir);
 
-    this.logger.info('Extracting archive...');
-    const { stderr, stdout } = await this.archiveManager.extractTarGz(archive, restoreDir);
-    this.logger.debug('--- archiveManager.extractTarGz ---');
-    this.logger.debug('stderr:', stderr);
-    this.logger.debug('stdout:', stdout);
+    try {
+      this.logger.info('Extracting archive...');
+      const { stderr, stdout } = await this.archiveManager.extractTarGz(archive, restoreDir);
+      this.logger.debug('--- archiveManager.extractTarGz ---');
+      this.logger.debug('stderr:', stderr);
+      this.logger.debug('stdout:', stdout);
 
-    const { appInstalledDir, appDataDir } = this.appFilesManager.getAppPaths(appUrn);
+      await this.validateRestoreDirectory(path.join(restoreDir, 'app-data'), { allowSymlinks: true });
+      await this.validateRestoreDirectory(path.join(restoreDir, 'app'), { allowSymlinks: true, rejectHardLinks: true });
+      await this.validateRestoreDirectory(path.join(restoreDir, 'user-config'), {
+        allowSymlinks: false,
+        optional: true,
+        rejectHardLinks: true,
+      });
 
-    // Remove old data directories
-    await this.filesystem.removeDirectory(appDataDir);
-    await this.filesystem.removeDirectory(appInstalledDir);
-    await this.filesystem.removeDirectory(userConfigDir);
+      const { appInstalledDir, appDataDir } = this.appFilesManager.getAppPaths(appUrn);
 
-    await this.filesystem.createDirectory(appDataDir);
-    await this.filesystem.createDirectory(appInstalledDir);
-    await this.filesystem.createDirectory(userConfigDir);
+      // Remove old data directories
+      await this.filesystem.removeDirectory(appDataDir);
+      await this.filesystem.removeDirectory(appInstalledDir);
+      await this.filesystem.removeDirectory(userConfigDir);
 
-    // Copy data from the backup folder
-    await this.filesystem.copyDirectory(path.join(restoreDir, 'app-data'), appDataDir);
-    await this.filesystem.copyDirectory(path.join(restoreDir, 'app'), appInstalledDir);
+      await this.filesystem.createDirectory(appDataDir);
+      await this.filesystem.createDirectory(appInstalledDir);
+      await this.filesystem.createDirectory(userConfigDir);
 
-    if (await this.filesystem.isDirectory(path.join(restoreDir, 'user-config'))) {
-      await this.filesystem.copyDirectory(path.join(restoreDir, 'user-config'), userConfigDir);
+      // Copy data from the backup folder
+      await this.filesystem.copyDirectory(path.join(restoreDir, 'app-data'), appDataDir);
+      await this.filesystem.copyDirectory(path.join(restoreDir, 'app'), appInstalledDir);
+
+      if (await this.filesystem.isDirectory(path.join(restoreDir, 'user-config'))) {
+        await this.filesystem.copyDirectory(path.join(restoreDir, 'user-config'), userConfigDir);
+      }
+    } finally {
+      await this.filesystem.removeDirectory(restoreDir);
+    }
+  };
+
+  private async validateRestoreDirectory(
+    directory: string,
+    options: { allowSymlinks: boolean; optional?: boolean; rejectHardLinks?: boolean },
+    rootDirectory = directory,
+  ): Promise<void> {
+    const directoryStats = await fs.promises.lstat(directory).catch((error: NodeJS.ErrnoException) => {
+      if (options.optional && error.code === 'ENOENT') {
+        return null;
+      }
+
+      throw error;
+    });
+
+    if (!directoryStats) {
+      return;
     }
 
-    // Delete restore folder
-    await this.filesystem.removeDirectory(restoreDir);
-  };
+    if (!directoryStats.isDirectory()) {
+      throw new Error('Backup contains unsupported file types');
+    }
+
+    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+    const rootPath = path.resolve(rootDirectory);
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        const entryPath = path.join(directory, entry.name);
+
+        if (entry.isSymbolicLink()) {
+          if (!options.allowSymlinks) {
+            throw new Error('Backup contains unsupported file types');
+          }
+
+          const linkTarget = await fs.promises.readlink(entryPath);
+          const resolvedTarget = path.resolve(path.dirname(entryPath), linkTarget);
+
+          if (!this.isPathInsideOrEqual(rootPath, resolvedTarget)) {
+            throw new Error('Backup contains unsupported file types');
+          }
+
+          return;
+        }
+
+        if (entry.isDirectory()) {
+          await this.validateRestoreDirectory(entryPath, options, rootDirectory);
+          return;
+        }
+
+        if (entry.isFile()) {
+          if (options.rejectHardLinks) {
+            const stats = await fs.promises.lstat(entryPath);
+
+            if (stats.nlink > 1) {
+              throw new Error('Backup contains unsupported file types');
+            }
+          }
+
+          return;
+        }
+
+        throw new Error('Backup contains unsupported file types');
+      }),
+    );
+  }
+
+  private isPathInsideOrEqual(parentPath: string, childPath: string): boolean {
+    const relativePath = path.relative(parentPath, childPath);
+
+    return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+  }
 
   /**
    * Delete a backup file


### PR DESCRIPTION
## Summary
- Adds restore-time validation for extracted backup contents before live directories are replaced.
- Rejects unsupported file types, symlinks that escape the restore root, and hard links in `app` and `user-config` content.
- Keeps cleanup in a `finally` block so the temporary restore directory is removed even when validation fails.
- Adds security-focused tests covering rejected symlink escapes and successful restoration of regular files and safe symlinks.

## Testing
- `Not run` in this environment.
- Existing unit coverage added in `packages/backend/src/modules/backups/__tests__/backup.manager.security.test.ts`.
- Validation checks exercised by tests for rejected unsafe symlinks and successful restore of regular files/directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup restore safety: stronger filesystem validation, rejects unsafe symlinks/hard links, ensures atomic cleanup and restore to prevent data loss.

* **Tests**
  * Added security tests covering unsafe symlink/hardlink scenarios and successful restore cases; test logging initialization was standardized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->