### PR TITLE
fix: fall back to si.mem() when /host/proc/meminfo is missing (LXC)

### DIFF
--- a/packages/backend/src/modules/system/__tests__/system.service.test.ts
+++ b/packages/backend/src/modules/system/__tests__/system.service.test.ts
@@ -1,0 +1,123 @@
+import { ConfigurationService } from '@/core/config/configuration.service';
+import { FilesystemService } from '@/core/filesystem/filesystem.service';
+import { LoggerService } from '@/core/logger/logger.service';
+import { Test } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+import si from 'systeminformation';
+import { SystemService } from '../system.service';
+
+describe('SystemService.getSystemLoad memory fallback (runtipi/runtipi#2445)', () => {
+  let service: SystemService;
+  let readTextFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    readTextFile = vi.fn();
+    // Clear any spies left over from earlier tests in this file so call-count
+    // assertions are deterministic across tests.
+    vi.restoreAllMocks();
+    const fakeFilesystem = { readTextFile } as unknown as FilesystemService;
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        SystemService,
+        { provide: FilesystemService, useValue: fakeFilesystem },
+        { provide: LoggerService, useValue: mock<LoggerService>() },
+        { provide: ConfigurationService, useValue: { get: vi.fn() } },
+      ],
+    }).compile();
+
+    service = moduleRef.get(SystemService);
+  });
+
+  it('uses /host/proc/meminfo when the bind-mount is present and well-formed', async () => {
+    const sample = [
+      'MemTotal:       16384000 kB',
+      'MemFree:         1234000 kB',
+      'MemAvailable:   8421000 kB',
+      'Buffers:          234000 kB',
+      'Cached:          4321000 kB',
+    ].join('\n');
+    readTextFile.mockResolvedValueOnce(sample);
+
+    const siMemSpy = vi.spyOn(si, 'mem');
+
+    const result = await service.getSystemLoad();
+
+    expect(readTextFile).toHaveBeenCalledWith('/host/proc/meminfo');
+    expect(siMemSpy).not.toHaveBeenCalled();
+    // 16384000 kB -> bytes = 16,777,216,000 -> /1024^3 -> 15.625 -> round to 16.
+    // Used = 16384000 - 8421000 = 7963000 kB ≈ 7.59 GB → round to 8.
+    // percent = 8/16 = 50%.
+    expect(result.memoryTotal).toBe(16);
+    expect(result.percentUsedMemory).toBe(50);
+  });
+
+  it('falls back to si.mem() when /host/proc/meminfo is unreadable (Proxmox LXC without the bind mount)', async () => {
+    readTextFile.mockRejectedValueOnce(new Error('ENOENT: no such file or directory'));
+
+    const siMemSpy = vi.spyOn(si, 'mem').mockResolvedValueOnce({
+      total: 16 * 1024 * 1024 * 1024,
+      free: 8 * 1024 * 1024 * 1024,
+      used: 8 * 1024 * 1024 * 1024,
+      active: 0,
+      available: 8 * 1024 * 1024 * 1024,
+      buffcache: 0,
+      buffers: 0,
+      cached: 0,
+      slab: 0,
+      reclaimable: 0,
+      swaptotal: 0,
+      swapused: 0,
+      swapfree: 0,
+      writeback: null,
+      dirty: null,
+    } as never);
+
+    const result = await service.getSystemLoad();
+
+    expect(readTextFile).toHaveBeenCalledWith('/host/proc/meminfo');
+    expect(siMemSpy).toHaveBeenCalledTimes(1);
+    expect(result.memoryTotal).toBe(16);
+    expect(result.percentUsedMemory).toBe(50);
+  });
+
+  it('falls back to si.mem() when /host/proc/meminfo is empty (regex yields 0)', async () => {
+    readTextFile.mockResolvedValueOnce('');
+
+    const siMemSpy = vi.spyOn(si, 'mem').mockResolvedValueOnce({
+      total: 8 * 1024 * 1024 * 1024,
+      free: 4 * 1024 * 1024 * 1024,
+      used: 4 * 1024 * 1024 * 1024,
+      active: 0,
+      available: 4 * 1024 * 1024 * 1024,
+      buffcache: 0,
+      buffers: 0,
+      cached: 0,
+      slab: 0,
+      reclaimable: 0,
+      swaptotal: 0,
+      swapused: 0,
+      swapfree: 0,
+      writeback: null,
+      dirty: null,
+    } as never);
+
+    const result = await service.getSystemLoad();
+
+    expect(siMemSpy).toHaveBeenCalledTimes(1);
+    expect(result.memoryTotal).toBe(8);
+    expect(result.percentUsedMemory).toBe(50);
+  });
+
+  it('returns 0% memory when both /host/proc/meminfo and si.mem() fail', async () => {
+    readTextFile.mockRejectedValueOnce(new Error('ENOENT'));
+    const siMemSpy = vi.spyOn(si, 'mem').mockRejectedValueOnce(new Error('si.mem() failed'));
+
+    const result = await service.getSystemLoad();
+
+    expect(siMemSpy).toHaveBeenCalledTimes(1);
+    expect(result.memoryTotal).toBe(0);
+    expect(result.percentUsedMemory).toBe(0);
+  });
+});

--- a/packages/backend/src/modules/system/system.service.ts
+++ b/packages/backend/src/modules/system/system.service.ts
@@ -27,6 +27,24 @@ export class SystemService {
       this.logger.error(`Unable to read /host/proc/meminfo: ${e}`);
     }
 
+    // Fallback to systeminformation's mem() when the bind-mount read fails or
+    // returns no data (e.g. Proxmox LXC without the /proc/meminfo bind mount,
+    // see runtipi/runtipi#2445). Without this, memoryTotal stays 0 and the
+    // dashboard shows a flat 0% memory usage.
+    if (memResult.total === 0) {
+      try {
+        const mem = await si.mem();
+        if (mem.total > 0) {
+          memResult.total = mem.total;
+          memResult.available = mem.available ?? mem.free ?? 0;
+          memResult.used = mem.used ?? mem.total - memResult.available;
+          this.logger.info('Using systeminformation.mem() fallback for memory stats (no /host/proc/meminfo).');
+        }
+      } catch (e) {
+        this.logger.error(`Unable to read memory via systeminformation: ${e}`);
+      }
+    }
+
     const [disk0] = await si.fsSize();
 
     const disk = disk0 ?? { available: 0, size: 0 };


### PR DESCRIPTION
## Problem
On Proxmox LXC hosts without the `/host/proc/meminfo` bind mount, the dashboard shows a flat **0% memory usage** because `SystemService.getSystemLoad()` only reads memory from that one source.

This is a real issue for users running Runtipi inside an LXC container (see #2445): `/host/proc/meminfo` is not bind-mounted, the read fails, and `memResult.total` stays at 0, so `memoryTotal` and `percentUsedMemory` both round to 0.

## Fix
Add a fallback to `systeminformation.mem()` when the bind-mount read fails **or** returns no data (regex yields 0). The fallback runs in addition to the existing bind-mount read — it only takes effect when bind-mount data is unavailable, so existing happy-path behavior is unchanged.

```ts
// Fallback to systeminformation's mem() when the bind-mount read fails or
// returns no data (e.g. Proxmox LXC without the /proc/meminfo bind mount).
if (memResult.total === 0) {
  try {
    const mem = await si.mem();
    if (mem.total > 0) {
      memResult.total = mem.total;
      memResult.available = mem.available ?? mem.free ?? 0;
      memResult.used = mem.used ?? mem.total - memResult.available;
    }
  } catch (e) {
    this.logger.error(`Unable to read memory via systeminformation: ${e}`);
  }
}
```

## How to test
1. `cd packages/backend && bun install --frozen-lockfile`
2. `bunx vitest run src/modules/system` — 6 tests pass (4 new + 2 pre-existing).
3. The 4 new tests cover:
   - `/host/proc/meminfo` present + well-formed → si.mem() NOT called
   - `/host/proc/meminfo` ENOENT → si.mem() called, fills memResult
   - `/host/proc/meminfo` empty string → si.mem() called, fills memResult
   - Both fail → memResult stays 0, dashboard returns 0% (no crash)

## Regression coverage
All 3 fallback paths fail without the source change. The "happy path" test (bind-mount works) fails if the fallback is invoked unconditionally.

Closes #2445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for system memory statistics verification, covering scenarios where the primary data source is accessible, unavailable, or returns empty values.

* **Bug Fixes**
  * Improved system memory statistics reliability by implementing a fallback mechanism that automatically switches to an alternative data source when the primary source becomes unavailable or returns insufficient data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->