### PR TITLE
fix: propagate RUNTIPI_* host env vars into per-app env files

### DIFF
--- a/packages/backend/src/modules/apps/__tests__/app.helpers.test.ts
+++ b/packages/backend/src/modules/apps/__tests__/app.helpers.test.ts
@@ -437,5 +437,55 @@ describe('AppHelpers', () => {
       // Assert - should use false, not the default
       expect(envMap.get('BOOLEAN_WITH_DEFAULT')).toBe('false');
     });
+
+    it('should propagate RUNTIPI_* host env vars into the app env file', async () => {
+      // Arrange — base env file has nothing, but process.env has RUNTIPI_* vars
+      // (https://github.com/runtipi/runtipi/issues/2382)
+      const envMap = new Map<string, string>();
+      envUtils.envStringToMap.mockReturnValue(envMap);
+      const originalEnv = process.env;
+      process.env = {
+        ...originalEnv,
+        RUNTIPI_MEDIA_PATH: '/mnt/media',
+        RUNTIPI_BACKUPS_PATH: '/mnt/backups',
+        NOT_RUNTIPI_FOO: 'should-not-be-propagated',
+      };
+
+      try {
+        // Act
+        await appHelpers.generateEnvFile(testAppUrn, {});
+
+        // Assert
+        expect(envMap.get('RUNTIPI_MEDIA_PATH')).toBe('/mnt/media');
+        expect(envMap.get('RUNTIPI_BACKUPS_PATH')).toBe('/mnt/backups');
+        expect(envMap.has('NOT_RUNTIPI_FOO')).toBe(false);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    it('should not overwrite RUNTIPI_* vars already set in the base env file', async () => {
+      // Arrange — base env file already has RUNTIPI_APP_DATA_PATH; process.env has a
+      // different value (e.g. a stale export from the shell). The .env is authoritative.
+      const envMap = new Map<string, string>([['RUNTIPI_APP_DATA_PATH', '/data/from-env-file']]);
+      envUtils.envStringToMap.mockReturnValue(envMap);
+      const originalEnv = process.env;
+      process.env = {
+        ...originalEnv,
+        RUNTIPI_APP_DATA_PATH: '/data/from-process-env',
+        RUNTIPI_NEW_VAR: '/data/new',
+      };
+
+      try {
+        // Act
+        await appHelpers.generateEnvFile(testAppUrn, {});
+
+        // Assert — the value from the .env file wins; the new var is still added
+        expect(envMap.get('RUNTIPI_APP_DATA_PATH')).toBe('/data/from-env-file');
+        expect(envMap.get('RUNTIPI_NEW_VAR')).toBe('/data/new');
+      } finally {
+        process.env = originalEnv;
+      }
+    });
   });
 });

--- a/packages/backend/src/modules/apps/app.helpers.ts
+++ b/packages/backend/src/modules/apps/app.helpers.ts
@@ -41,6 +41,23 @@ export class AppHelpers {
     const baseEnvFile = await this.filesytem.readTextFile(envFilePath);
     const envMap = this.envUtils.envStringToMap(baseEnvFile?.toString() ?? '');
 
+    // Propagate RUNTIPI_* host env vars into the app's env file so apps can
+    // reference them via ${VAR} interpolation in their compose/env files.
+    // Without this, vars like RUNTIPI_MEDIA_PATH were documented as available
+    // to apps but were never actually written to the per-app env file.
+    // See https://github.com/runtipi/runtipi/issues/2382
+    for (const [key, value] of Object.entries(process.env)) {
+      if (!key.startsWith('RUNTIPI_')) continue;
+      if (value === undefined) continue;
+      // Don't clobber a value that was set explicitly above (e.g. RUNTIPI_APP_DATA_PATH
+      // coming from the runtipi .env, which is already in envMap via baseEnvFile).
+      // The first pass wins — the .env file is the source of truth for the runtipi
+      // host, and we're just filling in any RUNTIPI_* vars that aren't already there.
+      if (!envMap.has(key)) {
+        envMap.set(key, value);
+      }
+    }
+
     const { appName, appStoreId } = extractAppUrn(appUrn);
 
     // Default always present env variables


### PR DESCRIPTION
Fixes #2382.

## Problem

Apps that reference `${RUNTIPI_MEDIA_PATH}` (or any other `RUNTIPI_*` prefixed host env var) in their `docker-compose.yml` fail with errors like:

```
invalid spec: :/mnt/media: empty section between colons
```

because those vars are never copied into the per-app `.env` file that `docker compose` loads via `--env-file`. The reference docs in `packages/backend/src/modules/apps/app.helpers.ts` imply they're available to apps, but `generateEnvFile` only writes the app's own form fields plus a few hardcoded `APP_*` keys.

## Fix

Before `generateEnvFile` writes the merged env map, scan `process.env` for any var starting with `RUNTIPI_` and add it to the map unless it's already present. The host's `.env` file remains authoritative for vars it sets explicitly (e.g. `RUNTIPI_APP_DATA_PATH`), so users keep full control of overrides.

```ts
for (const [key, value] of Object.entries(process.env)) {
  if (!key.startsWith('RUNTIPI_')) continue;
  if (value === undefined) continue;
  if (!envMap.has(key)) {
    envMap.set(key, value);
  }
}
```

## How to test

1. Set `RUNTIPI_MEDIA_PATH=/mnt/media` in `/opt/runtipi/.env`
2. Install or update an app
3. `cat /opt/runtipi/app-data/<store>/<app>/app.env | grep RUNTIPI` — should show the var
4. Reference `${RUNTIPI_MEDIA_PATH}` in the app's `docker-compose.yml` — should now resolve

## Tests

- 2 new unit tests in `app.helpers.test.ts` (one for the happy path, one for the no-clobber rule)
- Both fail on the unfixed code, pass on the fix
- Full backend suite: 228/228 green
- `biome check`: clean
- `tsc --noEmit`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications can now directly access system RUNTIPI_* environment variables for improved flexibility, with application-specific configuration maintaining precedence over host environment values.

* **Tests**
  * Added test cases to validate RUNTIPI_* variable propagation into application environments, including precedence rules and handling of undefined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->