### PR TITLE
Security: Hardcoded database credentials in drizzle config

### DIFF
--- a/packages/backend/drizzle.config.ts
+++ b/packages/backend/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   schema: './src/core/database/drizzle/schema.ts',
   out: './src/core/database/drizzle',
   dbCredentials: {
-    url: 'postgresql://tipi:postgres@localhost:5432/tipi?connect_timeout=300',
+    url: process.env.DATABASE_URL,
   },
 });


### PR DESCRIPTION
## Problem

The PostgreSQL connection string contains hardcoded credentials (username 'tipi', password 'postgres') in source code committed to a public repository. If these credentials match any deployed instance (common in self-hosted projects like Runtipi), attackers gain direct database access without any authentication bypass needed.


**Severity**: `high`
**File**: `packages/backend/drizzle.config.ts`

## Solution

The PostgreSQL connection string contains hardcoded credentials (username 'tipi', password 'postgres') in source code committed to a public repository. If these credentials match any deployed instance (common in self-hosted projects like Runtipi), attackers gain direct database access without any authentication bypass needed.


## Changes

- `packages/backend/drizzle.config.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connection setup to use the runtime environment variable instead of a fixed local address, making deployments more flexible across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->