### PR TITLE
UI/UX: Missing error boundary on unauthenticated routes causes unrecoverable crash

### DIFF
--- a/packages/frontend/src/components/routes/unauthenticated-route.tsx
+++ b/packages/frontend/src/components/routes/unauthenticated-route.tsx
@@ -1,16 +1,19 @@
 import { Suspense } from 'react';
 import { Outlet } from 'react-router';
 import { AuthLayout } from '../layouts/auth/layout';
+import { ErrorBoundary } from '../error-boundary';
 import { RouteWrapper } from './route-wrapper';
 
 export default () => {
   return (
     <RouteWrapper>
-      <Suspense fallback={<AuthLayout />}>
-        <AuthLayout>
-          <Outlet />
-        </AuthLayout>
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense fallback={<AuthLayout />}>
+          <AuthLayout>
+            <Outlet />
+          </AuthLayout>
+        </Suspense>
+      </ErrorBoundary>
     </RouteWrapper>
   );
 };


### PR DESCRIPTION
## Problem

The unauthenticated route (login/register pages) has no ErrorBoundary, while the authenticated route properly wraps content in `QueryErrorResetBoundary` + `ErrorBoundary` with a recovery mechanism. If an API call or component throws during login/registration, users see a white screen with no way to recover without manually refreshing.


**Severity**: `high`
**File**: `packages/frontend/src/components/routes/unauthenticated-route.tsx`

## Solution

The unauthenticated route (login/register pages) has no ErrorBoundary, while the authenticated route properly wraps content in `QueryErrorResetBoundary` + `ErrorBoundary` with a recovery mechanism. If an API call or component throws during login/registration, users see a white screen with no way to recover without manually refreshing.


## Changes

- `packages/frontend/src/components/routes/unauthenticated-route.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling around the unauthenticated route flow to prevent blank or broken screens when loading auth content.
  * Improved resilience for the authentication layout and nested page rendering while keeping the existing route experience unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->