### PR TITLE
Quality: Hardcoded database URL in drizzle config will fail in Docker and expose credentials

### DIFF
--- a/packages/backend/drizzle.config.ts
+++ b/packages/backend/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   schema: './src/core/database/drizzle/schema.ts',
   out: './src/core/database/drizzle',
   dbCredentials: {
-    url: 'postgresql://tipi:postgres@localhost:5432/tipi?connect_timeout=300',
+    url: process.env.DATABASE_URL || 'postgresql://tipi:postgres@localhost:5432/tipi?connect_timeout=300',
   },
 });


### PR DESCRIPTION
## Problem

The database connection URL is hardcoded to `postgresql://tipi:postgres@localhost:5432/tipi`. In a Docker-based deployment (as indicated by the project's stack), the database host is typically a Docker service name (e.g., `db` or `postgres`), not `localhost`. Running `drizzle-kit migrate` or `drizzle-kit push` in Docker will fail because it cannot reach the database. Additionally, default credentials (`tipi:postgres`) are embedded in source control, which is a security concern. Drizzle-kit supports reading from environment variables directly.


**Severity**: `high`
**File**: `packages/backend/drizzle.config.ts`

## Solution

The database connection URL is hardcoded to `postgresql://tipi:postgres@localhost:5432/tipi`. In a Docker-based deployment (as indicated by the project's stack), the database host is typically a Docker service name (e.g., `db` or `postgres`), not `localhost`. Running `drizzle-kit migrate` or `drizzle-kit push` in Docker will fail because it cannot reach the database. Additionally, default credentials (`tipi:postgres`) are embedded in source control, which is a security concern. Drizzle-kit supports reading from environment variables directly.


## Changes

- `packages/backend/drizzle.config.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database connection setup to prefer the `DATABASE_URL` environment variable, with a fallback to the existing default if it isn’t provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->