### PR TITLE
fix(frontend): Early return custom app form validation errors

### DIFF
--- a/packages/frontend/src/modules/app/pages/custom-app-create-page.tsx
+++ b/packages/frontend/src/modules/app/pages/custom-app-create-page.tsx
@@ -21,11 +21,11 @@ export default () => {
   const { composeExtras, setComposeExtras } = useMultiServiceStore();
 
   const appNameSchema = type('string').narrow((name, ctx) => {
-    if (name.length < 1) ctx.reject({ message: t('CUSTOM_APP_NAME_REQUIRED') });
-    if (name.length > 50) ctx.reject({ message: t('CUSTOM_APP_NAME_MAX_LENGTH') });
-    if (!/^[a-z0-9-]+$/.test(name)) ctx.reject({ message: t('CUSTOM_APP_NAME_VALIDATION_HELP') });
-    if (name.startsWith('-') || name.endsWith('-')) ctx.reject({ message: t('CUSTOM_APP_NAME_NO_HYPHEN_EDGES') });
-    if (RESERVED_APP_NAMES.includes(name.toLowerCase())) ctx.reject({ message: t('CUSTOM_APP_NAME_RESERVED') });
+    if (name.length < 1) return ctx.reject({ message: t('CUSTOM_APP_NAME_REQUIRED') });
+    if (name.length > 50) return ctx.reject({ message: t('CUSTOM_APP_NAME_MAX_LENGTH') });
+    if (!/^[a-z0-9-]+$/.test(name)) return ctx.reject({ message: t('CUSTOM_APP_NAME_VALIDATION_HELP') });
+    if (name.startsWith('-') || name.endsWith('-')) return ctx.reject({ message: t('CUSTOM_APP_NAME_NO_HYPHEN_EDGES') });
+    if (RESERVED_APP_NAMES.includes(name.toLowerCase())) return ctx.reject({ message: t('CUSTOM_APP_NAME_RESERVED') });
     return true;
   });
 


### PR DESCRIPTION
- Ark validation errors kept accumulating when more than a single APP_NAME error happens for a scenario
- Early returning the validation error fixes the bug
- This fixes #2623 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom app-name validation to stop immediately when a name is empty, too long, incorrectly formatted, starts or ends with a hyphen, or uses a reserved name.
  * Invalid names are now rejected consistently with the appropriate validation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->