### PR TITLE
fix(app-lifecycle): make app updates transactional

### DIFF
--- a/packages/backend/src/core/filesystem/filesystem.service.ts
+++ b/packages/backend/src/core/filesystem/filesystem.service.ts
@@ -117,7 +117,7 @@ export class FilesystemService {
     }
   }
 
-  async writePrivateTextFile(filePath: string, content: string): Promise<boolean> {
+  async writePrivateTextFile(filePath: string, content: string) {
     try {
       await fs.promises.mkdir(this.getSafeFilePath(filePath.split('/').slice(0, -1).join('/')), { recursive: true });
       const safeFilePath = this.getSafeFilePath(filePath);

--- a/packages/backend/src/core/filesystem/filesystem.service.ts
+++ b/packages/backend/src/core/filesystem/filesystem.service.ts
@@ -117,6 +117,19 @@ export class FilesystemService {
     }
   }
 
+  async writePrivateTextFile(filePath: string, content: string): Promise<boolean> {
+    try {
+      await fs.promises.mkdir(this.getSafeFilePath(filePath.split('/').slice(0, -1).join('/')), { recursive: true });
+      const safeFilePath = this.getSafeFilePath(filePath);
+      await fs.promises.writeFile(safeFilePath, content, { encoding: 'utf8', mode: 0o600 });
+      await fs.promises.chmod(safeFilePath, 0o600);
+      return true;
+    } catch (error) {
+      this.logger.error(`Error writing private file ${filePath}:`, error);
+      return false;
+    }
+  }
+
   async writeBinaryFile(filePath: string, data: Buffer): Promise<boolean> {
     try {
       await fs.promises.mkdir(this.getSafeFilePath(filePath.split('/').slice(0, -1).join('/')), { recursive: true });

--- a/packages/backend/src/modules/app-lifecycle/app-lifecycle-command.factory.ts
+++ b/packages/backend/src/modules/app-lifecycle/app-lifecycle-command.factory.ts
@@ -44,7 +44,7 @@ export class AppLifecycleCommandFactory {
       case 'generate_env':
         return new GenerateAppEnvCommand(this.moduleRef, this.docker);
       case 'update':
-        return new UpdateAppCommand(this.moduleRef, this.docker, eventData.performBackup);
+        return new UpdateAppCommand(this.moduleRef, this.docker, eventData.performBackup, eventData.wasRunningBeforeUpdate);
       default:
         throw new Error(`Unknown command: ${command}`);
     }

--- a/packages/backend/src/modules/app-lifecycle/app-lifecycle.service.ts
+++ b/packages/backend/src/modules/app-lifecycle/app-lifecycle.service.ts
@@ -48,8 +48,7 @@ export class AppLifecycleService {
 
     try {
       const command = this.commandFactory.createCommand(data);
-      const { success, message } = await command.execute(data.appUrn, data.form);
-      await reply({ success, message });
+      await reply(await command.execute(data.appUrn, data.form));
     } catch (err) {
       this.logger.error('Error invoking command:', err);
       await reply({ success: false, message: String(err) });

--- a/packages/backend/src/modules/app-lifecycle/commands/command.ts
+++ b/packages/backend/src/modules/app-lifecycle/commands/command.ts
@@ -17,18 +17,24 @@ export class AppLifecycleCommand {
     protected docker: Dockerode,
   ) {}
 
-  protected async ensureAppDir(appUrn: AppUrn, form: AppEventFormInput): Promise<void> {
+  protected async ensureAppDir(
+    appUrn: AppUrn,
+    form: AppEventFormInput,
+    options: { pruneContainers?: boolean; persistSubnet?: boolean } = {},
+  ): Promise<void> {
     const appFilesManager = this.moduleRef.get(AppFilesManager, { strict: false });
     const marketplaceService = this.moduleRef.get(MarketplaceService, { strict: false });
     const logger = this.moduleRef.get(LoggerService, { strict: false });
     const subnetManager = this.moduleRef.get(SubnetManagerService, { strict: false });
     const configService = this.moduleRef.get(ConfigurationService, { strict: false });
 
-    const pruned = await this.docker
-      .pruneContainers({ filters: { label: [`runtipi.appurn=${appUrn}`] } })
-      .catch(() => ({ ContainersDeleted: [], SpaceReclaimed: 0 }));
+    if (options.pruneContainers !== false) {
+      const pruned = await this.docker
+        .pruneContainers({ filters: { label: [`runtipi.appurn=${appUrn}`] } })
+        .catch(() => ({ ContainersDeleted: [], SpaceReclaimed: 0 }));
 
-    logger.info('Pruned containers:', pruned.ContainersDeleted, 'Space reclaimed:', pruned.SpaceReclaimed / 1024 / 1024, 'MB');
+      logger.info('Pruned containers:', pruned.ContainersDeleted, 'Space reclaimed:', pruned.SpaceReclaimed / 1024 / 1024, 'MB');
+    }
 
     let composeJson = await appFilesManager.getSourceDockerComposeYaml(appUrn);
 
@@ -44,7 +50,7 @@ export class AppLifecycleCommand {
       const architecture = configService.get('architecture');
 
       const dockerComposeBuilder = new DockerComposeBuilder();
-      const subnet = await subnetManager.allocateSubnet(appUrn);
+      const subnet = await subnetManager.allocateSubnet(appUrn, { persist: options.persistSubnet });
       const composeFile = dockerComposeBuilder.getDockerCompose(composeJson.content, form, appUrn, subnet, architecture);
 
       await appFilesManager.writeDockerComposeYml(appUrn, composeFile);

--- a/packages/backend/src/modules/app-lifecycle/commands/command.ts
+++ b/packages/backend/src/modules/app-lifecycle/commands/command.ts
@@ -17,11 +17,7 @@ export class AppLifecycleCommand {
     protected docker: Dockerode,
   ) {}
 
-  protected async ensureAppDir(
-    appUrn: AppUrn,
-    form: AppEventFormInput,
-    options: { pruneContainers?: boolean; persistSubnet?: boolean } = {},
-  ): Promise<void> {
+  protected async ensureAppDir(appUrn: AppUrn, form: AppEventFormInput, options: { pruneContainers?: boolean; persistSubnet?: boolean } = {}) {
     const appFilesManager = this.moduleRef.get(AppFilesManager, { strict: false });
     const marketplaceService = this.moduleRef.get(MarketplaceService, { strict: false });
     const logger = this.moduleRef.get(LoggerService, { strict: false });

--- a/packages/backend/src/modules/app-lifecycle/commands/install-app-command.ts
+++ b/packages/backend/src/modules/app-lifecycle/commands/install-app-command.ts
@@ -42,7 +42,7 @@ export class InstallAppCommand extends AppLifecycleCommand {
 
       // Copy data dir
       const appEnv = await appFilesManager.getAppEnv(appUrn);
-      const envMap = envUtils.envStringToMap(appEnv.content);
+      const envMap = envUtils.envStringToMap(appEnv.content ?? '');
 
       logger.info(`Copying data dir for app ${appUrn}`);
       await marketplaceService.copyDataDir(appUrn, envMap);

--- a/packages/backend/src/modules/app-lifecycle/commands/reset-app-command.ts
+++ b/packages/backend/src/modules/app-lifecycle/commands/reset-app-command.ts
@@ -45,7 +45,7 @@ export class ResetAppCommand extends AppLifecycleCommand {
       // Copy data dir
       logger.info(`Copying data dir for app ${appUrn}`);
       const env = await appFilesManager.getAppEnv(appUrn);
-      const envMap = envUtils.envStringToMap(env.content);
+      const envMap = envUtils.envStringToMap(env.content ?? '');
 
       await marketplaceService.copyDataDir(appUrn, envMap);
       await this.ensureAppDir(appUrn, form);

--- a/packages/backend/src/modules/app-lifecycle/commands/update-app-command.test.ts
+++ b/packages/backend/src/modules/app-lifecycle/commands/update-app-command.test.ts
@@ -1,4 +1,5 @@
 import { ConfigurationService } from '@/core/config/configuration.service';
+import { FilesystemService } from '@/core/filesystem/filesystem.service';
 import { LoggerService } from '@/core/logger/logger.service';
 import { AppFilesManager } from '@/modules/apps/app-files-manager';
 import { AppHelpers } from '@/modules/apps/app.helpers';
@@ -6,16 +7,20 @@ import { AppsRepository } from '@/modules/apps/apps.repository';
 import { BackupManager } from '@/modules/backups/backup.manager';
 import { DockerService } from '@/modules/docker/docker.service';
 import { MarketplaceService } from '@/modules/marketplace/marketplace.service';
+import { SubnetManagerService } from '@/modules/network/subnet-manager.service';
 import { convertLegacyToYaml } from '@runtipi/common/schemas';
 import type { AppUrn } from '@runtipi/common/types';
 import type { ModuleRef } from '@nestjs/core';
 import type Dockerode from 'dockerode';
-import { test, expect, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 import { UpdateAppCommand } from './update-app-command';
 
-test('applies backup retention after an update backup using the global limit when the app has no override', async () => {
-  const appUrn = 'app:test' as AppUrn;
+const appUrn = 'app:test' as AppUrn;
+
+const createCommand = (
+  options: { performBackup?: boolean; wasRunningBeforeUpdate?: boolean; stubEnsureAppDir?: boolean; initialSubnet?: string | null } = {},
+) => {
   const logger = mock<LoggerService>();
   const appFilesManager = mock<AppFilesManager>();
   const dockerService = mock<DockerService>();
@@ -24,9 +29,13 @@ test('applies backup retention after an update backup using the global limit whe
   const backupManager = mock<BackupManager>();
   const appsRepository = mock<AppsRepository>();
   const config = mock<ConfigurationService>();
+  const filesystem = mock<FilesystemService>();
   const docker = mock<Dockerode>();
+  const appState = { id: 1, subnet: options.initialSubnet ?? (null as string | null), maxBackups: null };
+  const subnetManager = new SubnetManagerService(appsRepository, logger, docker);
 
   dockerService.composeApp.mockResolvedValue({ success: true, stdout: '', stderr: '' });
+  docker.listNetworks.mockResolvedValue([]);
   marketplaceService.getSourceDockerComposeYaml.mockResolvedValue({
     path: '/app/apps/test/docker-compose.yml',
     content: convertLegacyToYaml({
@@ -34,13 +43,36 @@ test('applies backup retention after an update backup using the global limit whe
       services: [{ name: 'app', image: 'nginx:latest', isMain: true, internalPort: 80 }],
     }),
   });
-  appHelpers.generateEnvFile.mockResolvedValue(undefined);
-  appFilesManager.deleteAppFolder.mockResolvedValue(undefined);
+  appFilesManager.getSourceDockerComposeYaml.mockResolvedValue({
+    path: '/data/apps/test/docker-compose.yml',
+    content: convertLegacyToYaml({
+      schemaVersion: 2,
+      services: [{ name: 'app', image: 'nginx:latest', isMain: true, internalPort: 80 }],
+    }),
+  });
+  appFilesManager.getAppPaths.mockReturnValue({ appDataDir: '/data/app-data/test', appInstalledDir: '/data/apps/test' });
+  appFilesManager.getAppEnv.mockResolvedValue({ path: '/data/app-data/test/app.env', content: 'OLD_ENV=value' });
+  appFilesManager.deleteAppFolder.mockResolvedValue(true);
+  appFilesManager.writeAppEnv.mockResolvedValue(true);
   marketplaceService.copyAppFromRepoToInstalled.mockResolvedValue(undefined);
+  appHelpers.generateEnvFile.mockResolvedValue(undefined);
   backupManager.backupApp.mockResolvedValue(undefined);
   backupManager.cleanupOldBackups.mockResolvedValue(undefined);
-  appsRepository.getAppByUrn.mockResolvedValue({ maxBackups: null } as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
+  appsRepository.getAppByUrn.mockImplementation(async () => appState as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
+  appsRepository.getApps.mockImplementation(async () => [appState] as Awaited<ReturnType<AppsRepository['getApps']>>);
+  appsRepository.updateAppById.mockImplementation(async (_id, update) => {
+    if ('subnet' in update && update.subnet !== undefined) {
+      appState.subnet = update.subnet;
+    }
+    return appState as Awaited<ReturnType<AppsRepository['updateAppById']>>;
+  });
   config.get.calledWith('userSettings').mockReturnValue({ maxBackups: 7 } as never);
+  filesystem.createTempDirectory.mockResolvedValue('/tmp/runtipi-update-abc');
+  filesystem.copyDirectory.mockResolvedValue(true);
+  filesystem.removeDirectory.mockResolvedValue(true);
+  filesystem.writePrivateTextFile.mockResolvedValue(true);
+  filesystem.readTextFile.mockResolvedValue(JSON.stringify({ content: 'OLD_ENV=value' }));
+  filesystem.isFile.mockResolvedValue(true);
 
   const services = new Map<unknown, unknown>([
     [LoggerService, logger],
@@ -51,20 +83,336 @@ test('applies backup retention after an update backup using the global limit whe
     [BackupManager, backupManager],
     [AppsRepository, appsRepository],
     [ConfigurationService, config],
+    [FilesystemService, filesystem],
+    [SubnetManagerService, subnetManager],
   ]);
 
-  const moduleRef = {
-    get: (token: unknown) => services.get(token),
-  } as ModuleRef;
+  const moduleRef = { get: (token: unknown) => services.get(token) } as ModuleRef;
+  const command = new UpdateAppCommand(moduleRef, docker, options.performBackup ?? true, options.wasRunningBeforeUpdate ?? false);
+  const ensureAppDir =
+    options.stubEnsureAppDir === false
+      ? undefined
+      : vi.spyOn(command as UpdateAppCommand & { ensureAppDir: (...args: unknown[]) => Promise<void> }, 'ensureAppDir').mockResolvedValue(undefined);
 
-  const command = new UpdateAppCommand(moduleRef, docker, true);
-  vi.spyOn(
-    command as UpdateAppCommand & { ensureAppDir: (appUrn: AppUrn, form: Record<string, unknown>) => Promise<void> },
-    'ensureAppDir',
-  ).mockResolvedValue();
+  return {
+    command,
+    dockerService,
+    logger,
+    marketplaceService,
+    appFilesManager,
+    appHelpers,
+    backupManager,
+    filesystem,
+    ensureAppDir,
+    appsRepository,
+    appState,
+  };
+};
+
+test('pulls the target images before stopping or removing the existing deployment', async () => {
+  const { command, dockerService, backupManager, filesystem, ensureAppDir } = createCommand();
 
   const result = await command.execute(appUrn, {});
 
   expect(result).toEqual({ success: true, message: `App ${appUrn} updated successfully` });
+  expect(dockerService.composeApp.mock.calls.map(([, command]) => command)).toEqual(['pull', 'stop', 'down --remove-orphans']);
+  expect(dockerService.composeApp).not.toHaveBeenCalledWith(appUrn, expect.stringContaining('--rmi all'));
   expect(backupManager.cleanupOldBackups).toHaveBeenCalledWith(appUrn, 7);
+  expect(filesystem.copyDirectory).toHaveBeenNthCalledWith(1, '/data/apps/test', '/tmp/runtipi-update-abc/previous-app');
+  expect(filesystem.copyDirectory).toHaveBeenNthCalledWith(2, '/tmp/runtipi-update-abc/previous-app', '/data/apps/test');
+  expect(ensureAppDir).toHaveBeenCalledWith(appUrn, {}, { pruneContainers: false, persistSubnet: false });
+});
+
+test('does not allocate a subnet when a preflight pull fails', async () => {
+  const { command, dockerService, appsRepository, appState } = createCommand({ stubEnsureAppDir: false });
+  dockerService.composeApp.mockRejectedValueOnce(new Error('registry unavailable'));
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: false, message: 'registry unavailable', rollbackSucceeded: true });
+  expect(appState.subnet).toBeNull();
+  expect(appsRepository.updateAppById).not.toHaveBeenCalled();
+});
+
+test('keeps the original subnet in the database and restored compose when final target generation fails', async () => {
+  const originalSubnet = '10.128.42.0/24';
+  const { command, appFilesManager, appHelpers, appsRepository, appState, marketplaceService } = createCommand({
+    initialSubnet: originalSubnet,
+    stubEnsureAppDir: false,
+    wasRunningBeforeUpdate: true,
+  });
+  const multiServiceCompose = convertLegacyToYaml({
+    schemaVersion: 2,
+    services: [
+      { name: 'app', image: 'nginx:latest', isMain: true, internalPort: 80 },
+      { name: 'worker', image: 'nginx:latest' },
+    ],
+  });
+  marketplaceService.getSourceDockerComposeYaml.mockResolvedValue({ path: '/app/apps/test/docker-compose.yml', content: multiServiceCompose });
+  appFilesManager.getSourceDockerComposeYaml.mockResolvedValue({ path: '/data/apps/test/docker-compose.yml', content: multiServiceCompose });
+  appHelpers.generateEnvFile.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('target environment unavailable'));
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: false, message: 'target environment unavailable', rollbackSucceeded: true });
+  expect(appState.subnet).toBe(originalSubnet);
+  expect(appsRepository.updateAppById).not.toHaveBeenCalled();
+  expect(appFilesManager.writeDockerComposeYml.mock.calls.map(([, compose]) => compose)).toHaveLength(3);
+  for (const [, compose] of appFilesManager.writeDockerComposeYml.mock.calls) {
+    expect(compose).toContain(originalSubnet);
+  }
+});
+
+test('restores a legacy null subnet after final target generation fails', async () => {
+  const { command, appHelpers, appsRepository, appState } = createCommand({ stubEnsureAppDir: false, wasRunningBeforeUpdate: true });
+  appHelpers.generateEnvFile.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('target environment unavailable'));
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: false, message: 'target environment unavailable', rollbackSucceeded: true });
+  expect(appState.subnet).toBeNull();
+  expect(appsRepository.updateAppById).toHaveBeenCalledWith(1, { subnet: '10.128.10.0/24' });
+  expect(appsRepository.updateAppById).toHaveBeenLastCalledWith(1, { subnet: null });
+});
+
+test('persists a subnet for a legacy null-subnet app after a successful update', async () => {
+  const { command, appsRepository, appState } = createCommand({ stubEnsureAppDir: false });
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: true, message: `App ${appUrn} updated successfully` });
+  expect(appState.subnet).toBe('10.128.10.0/24');
+  expect(appsRepository.updateAppById).toHaveBeenCalledTimes(1);
+  expect(appsRepository.updateAppById).toHaveBeenCalledWith(1, { subnet: '10.128.10.0/24' });
+});
+
+test('restores the previous app files and leaves containers alone when the preflight pull fails', async () => {
+  const { command, dockerService, appFilesManager, filesystem, ensureAppDir } = createCommand();
+  dockerService.composeApp.mockRejectedValueOnce(new Error('registry unavailable'));
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: false, message: 'registry unavailable', rollbackSucceeded: true });
+  expect(dockerService.composeApp).toHaveBeenCalledWith(appUrn, 'pull');
+  expect(dockerService.composeApp).not.toHaveBeenCalledWith(appUrn, 'stop');
+  expect(dockerService.composeApp).not.toHaveBeenCalledWith(appUrn, 'down --remove-orphans');
+  expect(filesystem.copyDirectory).toHaveBeenNthCalledWith(2, '/tmp/runtipi-update-abc/previous-app', '/data/apps/test');
+  expect(appFilesManager.writeAppEnv).toHaveBeenCalledWith(appUrn, 'OLD_ENV=value');
+  expect(ensureAppDir).toHaveBeenCalledWith(appUrn, {}, { pruneContainers: false, persistSubnet: false });
+});
+
+test.each([
+  [
+    'copying the target app files',
+    (setup: ReturnType<typeof createCommand>) =>
+      setup.marketplaceService.copyAppFromRepoToInstalled.mockRejectedValueOnce(new Error(`Failed to copy app ${appUrn} from repo test`)),
+    `Failed to copy app ${appUrn} from repo test`,
+  ],
+  [
+    'writing the generated target compose file',
+    (setup: ReturnType<typeof createCommand>) =>
+      setup.ensureAppDir?.mockRejectedValueOnce(new Error(`Failed to write generated docker compose file for app ${appUrn}`)),
+    `Failed to write generated docker compose file for app ${appUrn}`,
+  ],
+  [
+    'writing the generated target environment',
+    (setup: ReturnType<typeof createCommand>) =>
+      setup.appHelpers.generateEnvFile.mockRejectedValueOnce(new Error(`Failed to write app environment for ${appUrn}`)),
+    `Failed to write app environment for ${appUrn}`,
+  ],
+])('restores the previous state and does not deploy when preflight fails while %s', async (_description, failPreflight, message) => {
+  const setup = createCommand();
+  failPreflight(setup);
+
+  const result = await setup.command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: false, message, rollbackSucceeded: true });
+  expect(setup.dockerService.composeApp).not.toHaveBeenCalled();
+  expect(setup.filesystem.copyDirectory).toHaveBeenNthCalledWith(2, '/tmp/runtipi-update-abc/previous-app', '/data/apps/test');
+  expect(setup.appFilesManager.writeAppEnv).toHaveBeenCalledWith(appUrn, 'OLD_ENV=value');
+});
+
+test('restores the previous deployment instead of starting the target when the final app copy fails', async () => {
+  const { command, dockerService, marketplaceService } = createCommand({ wasRunningBeforeUpdate: true });
+  marketplaceService.copyAppFromRepoToInstalled
+    .mockResolvedValueOnce(undefined)
+    .mockRejectedValueOnce(new Error(`Failed to copy app ${appUrn} from repo test`));
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: false, message: `Failed to copy app ${appUrn} from repo test`, rollbackSucceeded: true });
+  expect(dockerService.composeApp.mock.calls.map(([, composeCommand]) => composeCommand)).toEqual([
+    'pull',
+    'stop',
+    'down --remove-orphans',
+    'up --detach --force-recreate --remove-orphans',
+  ]);
+});
+
+test('persists and restores the previous environment from the durable recovery snapshot', async () => {
+  const { command, dockerService, appFilesManager, filesystem } = createCommand();
+  dockerService.composeApp.mockRejectedValueOnce(new Error('registry unavailable'));
+  filesystem.readTextFile.mockResolvedValue(JSON.stringify({ content: 'DURABLE_ENV=value' }));
+
+  await command.execute(appUrn, {});
+
+  expect(filesystem.writePrivateTextFile).toHaveBeenCalledWith(
+    '/tmp/runtipi-update-abc/previous-app.env.json',
+    JSON.stringify({ content: 'OLD_ENV=value' }),
+  );
+  expect(appFilesManager.writeAppEnv).toHaveBeenCalledWith(appUrn, 'DURABLE_ENV=value');
+});
+
+test('retains the recovery snapshot when restoring the previous environment fails', async () => {
+  const { command, dockerService, appFilesManager, filesystem } = createCommand();
+  dockerService.composeApp.mockRejectedValueOnce(new Error('registry unavailable'));
+  appFilesManager.writeAppEnv.mockResolvedValue(false);
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({
+    success: false,
+    message: 'registry unavailable. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
+    rollbackSucceeded: false,
+    recoverySnapshotPath: '/tmp/runtipi-update-abc',
+  });
+  expect(filesystem.removeDirectory).not.toHaveBeenCalled();
+});
+
+test('durably records a missing environment file and restores its absence', async () => {
+  const { command, dockerService, appFilesManager, filesystem } = createCommand();
+  appFilesManager.getAppEnv.mockResolvedValue({ path: '/data/app-data/test/app.env', content: null });
+  dockerService.composeApp.mockRejectedValueOnce(new Error('registry unavailable'));
+  filesystem.readTextFile.mockResolvedValue(JSON.stringify({ content: null }));
+
+  await command.execute(appUrn, {});
+
+  expect(filesystem.writePrivateTextFile).toHaveBeenCalledWith('/tmp/runtipi-update-abc/previous-app.env.json', JSON.stringify({ content: null }));
+  expect(filesystem.removeFile).toHaveBeenCalledWith('/data/app-data/test/app.env');
+});
+
+test.each([
+  [
+    'cannot read the current environment',
+    (setup: ReturnType<typeof createCommand>) => setup.appFilesManager.getAppEnv.mockRejectedValue(new Error('env unavailable')),
+  ],
+  [
+    'cannot create a staging directory',
+    (setup: ReturnType<typeof createCommand>) => setup.filesystem.createTempDirectory.mockRejectedValue(new Error('temp unavailable')),
+  ],
+])('reports rollback success when setup %s before changing the deployment', async (_description, failSetup) => {
+  const setup = createCommand();
+  failSetup(setup);
+
+  const result = await setup.command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: false, message: expect.stringMatching(/(env|temp) unavailable/), rollbackSucceeded: true });
+  expect(setup.marketplaceService.copyAppFromRepoToInstalled).not.toHaveBeenCalled();
+  expect(setup.dockerService.composeApp).not.toHaveBeenCalled();
+});
+
+test('starts the restored deployment when an update fails after a backup stopped a running app', async () => {
+  const { command, dockerService } = createCommand({ wasRunningBeforeUpdate: true });
+  dockerService.composeApp.mockImplementation(async (_appUrn, command) => {
+    if (command === 'down --remove-orphans') {
+      throw new Error('failed to stop old deployment');
+    }
+    return { success: true, stdout: '', stderr: '' };
+  });
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: false, message: 'failed to stop old deployment', rollbackSucceeded: true });
+  expect(dockerService.composeApp).toHaveBeenLastCalledWith(appUrn, 'up --detach --force-recreate --remove-orphans');
+});
+
+test('rolls back a target startup failure before reporting the update as failed', async () => {
+  const { command, dockerService, filesystem } = createCommand({ wasRunningBeforeUpdate: true });
+  let starts = 0;
+  dockerService.composeApp.mockImplementation(async (_appUrn, composeCommand) => {
+    if (composeCommand === 'up --detach --force-recreate --remove-orphans' && ++starts === 1) {
+      throw new Error('new version did not start');
+    }
+    return { success: true, stdout: '', stderr: '' };
+  });
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: false, message: 'new version did not start', rollbackSucceeded: true });
+  expect(dockerService.composeApp.mock.calls.map(([, composeCommand]) => composeCommand)).toEqual([
+    'pull',
+    'stop',
+    'down --remove-orphans',
+    'up --detach --force-recreate --remove-orphans',
+    'up --detach --force-recreate --remove-orphans',
+  ]);
+  expect(filesystem.removeDirectory).toHaveBeenCalledWith('/tmp/runtipi-update-abc');
+});
+
+test('logs a retained recovery snapshot when cleanup fails after a successful update', async () => {
+  const { command, filesystem, logger } = createCommand();
+  filesystem.removeDirectory.mockResolvedValue(false);
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({ success: true, message: `App ${appUrn} updated successfully` });
+  expect(logger.error).toHaveBeenCalledWith(
+    expect.stringContaining('Failed to remove recovery snapshot for app app:test at /tmp/runtipi-update-abc'),
+  );
+});
+
+test('retains the recovery snapshot when rollback startup fails', async () => {
+  const { command, dockerService, filesystem, logger } = createCommand({ wasRunningBeforeUpdate: true });
+  dockerService.composeApp.mockImplementation(async (_appUrn, composeCommand) => {
+    if (composeCommand === 'up --detach --force-recreate --remove-orphans') {
+      throw new Error('unable to start deployment');
+    }
+    return { success: true, stdout: '', stderr: '' };
+  });
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({
+    success: false,
+    message: 'unable to start deployment. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
+    rollbackSucceeded: false,
+    recoverySnapshotPath: '/tmp/runtipi-update-abc',
+  });
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Recovery snapshot retained at /tmp/runtipi-update-abc'), expect.any(Error));
+  expect(filesystem.removeDirectory).not.toHaveBeenCalled();
+});
+
+test('retains the recovery snapshot when previous files cannot be restored', async () => {
+  const { command, dockerService, filesystem } = createCommand({ wasRunningBeforeUpdate: true });
+  dockerService.composeApp.mockRejectedValueOnce(new Error('registry unavailable'));
+  filesystem.copyDirectory.mockImplementation(
+    async (source, destination) => source !== '/tmp/runtipi-update-abc/previous-app' || destination !== '/data/apps/test',
+  );
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({
+    success: false,
+    message: 'registry unavailable. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
+    rollbackSucceeded: false,
+    recoverySnapshotPath: '/tmp/runtipi-update-abc',
+  });
+  expect(filesystem.removeDirectory).not.toHaveBeenCalled();
+});
+
+test('retains the recovery snapshot when the current app folder cannot be removed for rollback', async () => {
+  const { command, dockerService, appFilesManager, filesystem } = createCommand();
+  dockerService.composeApp.mockRejectedValueOnce(new Error('registry unavailable'));
+  appFilesManager.deleteAppFolder.mockResolvedValue(false);
+
+  const result = await command.execute(appUrn, {});
+
+  expect(result).toEqual({
+    success: false,
+    message: 'registry unavailable. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
+    rollbackSucceeded: false,
+    recoverySnapshotPath: '/tmp/runtipi-update-abc',
+  });
+  expect(filesystem.copyDirectory).not.toHaveBeenCalledWith('/tmp/runtipi-update-abc/previous-app', '/data/apps/test');
+  expect(filesystem.removeDirectory).not.toHaveBeenCalled();
 });

--- a/packages/backend/src/modules/app-lifecycle/commands/update-app-command.test.ts
+++ b/packages/backend/src/modules/app-lifecycle/commands/update-app-command.test.ts
@@ -272,7 +272,8 @@ test('retains the recovery snapshot when restoring the previous environment fail
 
   expect(result).toEqual({
     success: false,
-    message: 'registry unavailable. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
+    message:
+      'registry unavailable. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc. After recovering the app, remove this directory manually.',
     rollbackSucceeded: false,
     recoverySnapshotPath: '/tmp/runtipi-update-abc',
   });
@@ -311,10 +312,26 @@ test.each([
   expect(setup.dockerService.composeApp).not.toHaveBeenCalled();
 });
 
+test('does not report a null recovery path when recovery fails before staging', async () => {
+  const setup = createCommand();
+  setup.filesystem.createTempDirectory.mockRejectedValue(new Error('temp unavailable'));
+  setup.appsRepository.getAppByUrn.mockResolvedValueOnce(setup.appState as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
+  setup.appsRepository.getAppByUrn.mockRejectedValueOnce(new Error('subnet unavailable'));
+
+  const result = await setup.command.execute(appUrn, {});
+
+  expect(result).toEqual({
+    success: false,
+    message: 'temp unavailable. Recovery failed before a recovery snapshot could be retained.',
+    rollbackSucceeded: false,
+  });
+  expect(result).not.toHaveProperty('recoverySnapshotPath');
+});
+
 test('starts the restored deployment when an update fails after a backup stopped a running app', async () => {
   const { command, dockerService } = createCommand({ wasRunningBeforeUpdate: true });
-  dockerService.composeApp.mockImplementation(async (_appUrn, command) => {
-    if (command === 'down --remove-orphans') {
+  dockerService.composeApp.mockImplementation(async (_appUrn, composeCommand) => {
+    if (composeCommand === 'down --remove-orphans') {
       throw new Error('failed to stop old deployment');
     }
     return { success: true, stdout: '', stderr: '' };
@@ -374,7 +391,8 @@ test('retains the recovery snapshot when rollback startup fails', async () => {
 
   expect(result).toEqual({
     success: false,
-    message: 'unable to start deployment. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
+    message:
+      'unable to start deployment. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc. After recovering the app, remove this directory manually.',
     rollbackSucceeded: false,
     recoverySnapshotPath: '/tmp/runtipi-update-abc',
   });
@@ -393,7 +411,8 @@ test('retains the recovery snapshot when previous files cannot be restored', asy
 
   expect(result).toEqual({
     success: false,
-    message: 'registry unavailable. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
+    message:
+      'registry unavailable. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc. After recovering the app, remove this directory manually.',
     rollbackSucceeded: false,
     recoverySnapshotPath: '/tmp/runtipi-update-abc',
   });
@@ -409,7 +428,8 @@ test('retains the recovery snapshot when the current app folder cannot be remove
 
   expect(result).toEqual({
     success: false,
-    message: 'registry unavailable. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
+    message:
+      'registry unavailable. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc. After recovering the app, remove this directory manually.',
     rollbackSucceeded: false,
     recoverySnapshotPath: '/tmp/runtipi-update-abc',
   });

--- a/packages/backend/src/modules/app-lifecycle/commands/update-app-command.ts
+++ b/packages/backend/src/modules/app-lifecycle/commands/update-app-command.ts
@@ -13,12 +13,15 @@ import { AppLifecycleCommand } from './command';
 import { dynamicComposeSchemaYaml } from '@runtipi/common/schemas';
 import { type } from 'arktype';
 import { ConfigurationService } from '@/core/config/configuration.service';
+import { FilesystemService } from '@/core/filesystem/filesystem.service';
+import path from 'node:path';
 
 export class UpdateAppCommand extends AppLifecycleCommand {
   constructor(
     moduleRef: ModuleRef,
     docker: Dockerode,
     private readonly performBackup: boolean = true,
+    private readonly wasRunningBeforeUpdate: boolean = false,
   ) {
     super(moduleRef, docker);
   }
@@ -32,17 +35,110 @@ export class UpdateAppCommand extends AppLifecycleCommand {
     const backupManager = this.moduleRef.get(BackupManager, { strict: false });
     const appsRepository = this.moduleRef.get(AppsRepository, { strict: false });
     const config = this.moduleRef.get(ConfigurationService, { strict: false });
+    const filesystem = this.moduleRef.get(FilesystemService, { strict: false });
 
-    const composeToInstall = await marketplaceService.getSourceDockerComposeYaml(appUrn);
-    const compose = dynamicComposeSchemaYaml(composeToInstall.content);
+    let temporaryDirectory: string | null = null;
+    let appInstalledDir: string | null = null;
+    let previousAppDirectory: string | null = null;
+    let previousEnvPath: string | null = null;
+    let previousEnvSnapshotPath: string | null = null;
+    let previousFilesStaged = false;
+    let subnetBeforeUpdate: { id: number; subnet: string | null } | null = null;
+    let deploymentMayHaveChanged = false;
+    let deploymentMayHaveStopped = false;
+    let recoverySucceeded = true;
 
-    if (compose instanceof type.errors) {
-      logger.error('Compose JSON validation errors:', compose.summary);
-      return this.handleAppError(compose.summary, appUrn, 'update_error');
-    }
+    const restorePreviousApp = async () => {
+      if (!previousAppDirectory || !appInstalledDir || !previousEnvPath || !previousEnvSnapshotPath) {
+        throw new Error(`Recovery snapshot is incomplete for app ${appUrn}`);
+      }
+
+      if (!(await filesystem.copyDirectory(previousAppDirectory, appInstalledDir))) {
+        throw new Error(`Failed to restore the previous files for app ${appUrn}`);
+      }
+
+      const envSnapshot = await filesystem.readTextFile(previousEnvSnapshotPath);
+      if (envSnapshot === null) {
+        throw new Error(`Failed to read the previous environment snapshot for app ${appUrn}`);
+      }
+
+      let previousEnv: unknown;
+      try {
+        previousEnv = JSON.parse(envSnapshot);
+      } catch {
+        throw new Error(`Failed to parse the previous environment snapshot for app ${appUrn}`);
+      }
+
+      if (
+        typeof previousEnv !== 'object' ||
+        previousEnv === null ||
+        !('content' in previousEnv) ||
+        (typeof previousEnv.content !== 'string' && previousEnv.content !== null)
+      ) {
+        throw new Error(`Invalid previous environment snapshot for app ${appUrn}`);
+      }
+
+      if (previousEnv.content !== null) {
+        if (!(await appFilesManager.writeAppEnv(appUrn, previousEnv.content))) {
+          throw new Error(`Failed to restore the previous environment for app ${appUrn}`);
+        }
+      } else if ((await filesystem.isFile(previousEnvPath)) && !(await filesystem.removeFile(previousEnvPath))) {
+        throw new Error(`Failed to remove the generated environment for app ${appUrn}`);
+      }
+    };
+
+    const clearAppFolderForRestore = async () => {
+      if (!(await appFilesManager.deleteAppFolder(appUrn))) {
+        throw new Error(`Failed to remove the current app files for app ${appUrn}`);
+      }
+    };
 
     try {
+      const composeToInstall = await marketplaceService.getSourceDockerComposeYaml(appUrn);
+      const compose = dynamicComposeSchemaYaml(composeToInstall.content);
+
+      if (compose instanceof type.errors) {
+        logger.error('Compose JSON validation errors:', compose.summary);
+        return { ...(await this.handleAppError(compose.summary, appUrn, 'update_error')), rollbackSucceeded: true };
+      }
+
+      const appBeforeUpdate = await appsRepository.getAppByUrn(appUrn);
+      if (appBeforeUpdate) {
+        subnetBeforeUpdate = { id: appBeforeUpdate.id, subnet: appBeforeUpdate.subnet };
+      }
+
+      appInstalledDir = appFilesManager.getAppPaths(appUrn).appInstalledDir;
+      const previousEnv = await appFilesManager.getAppEnv(appUrn);
+      previousEnvPath = previousEnv.path;
+      temporaryDirectory = await filesystem.createTempDirectory(path.join('/tmp', 'runtipi-update-'));
+      if (!temporaryDirectory) {
+        throw new Error(`Failed to create an update staging directory for app ${appUrn}`);
+      }
+
+      previousAppDirectory = path.join(temporaryDirectory, 'previous-app');
+      previousEnvSnapshotPath = path.join(temporaryDirectory, 'previous-app.env.json');
+
+      if (!(await filesystem.copyDirectory(appInstalledDir, previousAppDirectory))) {
+        throw new Error(`Failed to stage the current files for app ${appUrn}`);
+      }
+      previousFilesStaged = true;
+      if (!(await filesystem.writePrivateTextFile(previousEnvSnapshotPath, JSON.stringify({ content: previousEnv.content })))) {
+        throw new Error(`Failed to stage the previous environment for app ${appUrn}`);
+      }
+
+      // Pull from an isolated copy
+      deploymentMayHaveChanged = true;
+      await marketplaceService.copyAppFromRepoToInstalled(appUrn);
+      await this.ensureAppDir(appUrn, form, { pruneContainers: false, persistSubnet: false });
+      await appHelpers.generateEnvFile(appUrn, form);
+      await dockerService.composeApp(appUrn, 'pull');
+
+      // Restore the old compose before taking a backup
+      await clearAppFolderForRestore();
+      await restorePreviousApp();
+
       if (this.performBackup) {
+        deploymentMayHaveStopped = true;
         await dockerService.composeApp(appUrn, 'stop');
         await backupManager.backupApp(appUrn);
 
@@ -53,26 +149,63 @@ export class UpdateAppCommand extends AppLifecycleCommand {
       }
 
       logger.info(`Updating app ${appUrn}`);
-      await this.ensureAppDir(appUrn, form);
+      deploymentMayHaveStopped = true;
+      await dockerService.composeApp(appUrn, 'down --remove-orphans');
+
+      await marketplaceService.copyAppFromRepoToInstalled(appUrn);
+      await this.ensureAppDir(appUrn, form, { pruneContainers: false });
       await appHelpers.generateEnvFile(appUrn, form);
 
-      try {
+      if (this.wasRunningBeforeUpdate) {
         await dockerService.composeApp(appUrn, 'up --detach --force-recreate --remove-orphans');
-        await dockerService.composeApp(appUrn, 'down --rmi all --remove-orphans');
-      } catch (_) {
-        logger.warn(`App ${appUrn} has likely a broken compose file. Continuing with update...`);
       }
-
-      await appFilesManager.deleteAppFolder(appUrn);
-      await marketplaceService.copyAppFromRepoToInstalled(appUrn);
-
-      await this.ensureAppDir(appUrn, form);
-
-      await dockerService.composeApp(appUrn, 'pull');
 
       return { success: true, message: `App ${appUrn} updated successfully` };
     } catch (err) {
-      return this.handleAppError(err, appUrn, 'update_error');
+      try {
+        if (previousFilesStaged && deploymentMayHaveChanged) {
+          await clearAppFolderForRestore();
+          await restorePreviousApp();
+        }
+
+        if (subnetBeforeUpdate) {
+          const currentApp = await appsRepository.getAppByUrn(appUrn);
+          if (currentApp?.subnet !== subnetBeforeUpdate.subnet) {
+            await appsRepository.updateAppById(subnetBeforeUpdate.id, { subnet: subnetBeforeUpdate.subnet });
+          }
+        }
+
+        if (previousFilesStaged && deploymentMayHaveChanged && deploymentMayHaveStopped && this.wasRunningBeforeUpdate) {
+          await this.ensureAppDir(appUrn, form, { pruneContainers: false, persistSubnet: false });
+          await dockerService.composeApp(appUrn, 'up --detach --force-recreate --remove-orphans');
+        }
+      } catch (rollbackError) {
+        recoverySucceeded = false;
+        logger.error(`Failed to restore app ${appUrn} after an update error. Recovery snapshot retained at ${temporaryDirectory}:`, rollbackError);
+      }
+
+      const updateError = await this.handleAppError(err, appUrn, 'update_error');
+      if (!recoverySucceeded) {
+        return {
+          success: false,
+          rollbackSucceeded: false,
+          recoverySnapshotPath: temporaryDirectory,
+          message: `${updateError.message}. Recovery failed; the previous app files are retained at ${temporaryDirectory}.`,
+        };
+      }
+
+      return { ...updateError, rollbackSucceeded: true };
+    } finally {
+      if (temporaryDirectory && recoverySucceeded) {
+        try {
+          const removed = await filesystem.removeDirectory(temporaryDirectory);
+          if (!removed) {
+            logger.error(`Failed to remove recovery snapshot for app ${appUrn} at ${temporaryDirectory}; it may contain the previous environment.`);
+          }
+        } catch {
+          logger.error(`Failed to remove recovery snapshot for app ${appUrn} at ${temporaryDirectory}; it may contain the previous environment.`);
+        }
+      }
     }
   }
 }

--- a/packages/backend/src/modules/app-lifecycle/commands/update-app-command.ts
+++ b/packages/backend/src/modules/app-lifecycle/commands/update-app-command.ts
@@ -126,7 +126,8 @@ export class UpdateAppCommand extends AppLifecycleCommand {
         throw new Error(`Failed to stage the previous environment for app ${appUrn}`);
       }
 
-      // Pull from an isolated copy
+      // Stage the target files in the installed directory while the existing containers keep running.
+      // The previous files and compose are restored immediately after the target images are pulled.
       deploymentMayHaveChanged = true;
       await marketplaceService.copyAppFromRepoToInstalled(appUrn);
       await this.ensureAppDir(appUrn, form, { pruneContainers: false, persistSubnet: false });
@@ -181,16 +182,32 @@ export class UpdateAppCommand extends AppLifecycleCommand {
         }
       } catch (rollbackError) {
         recoverySucceeded = false;
-        logger.error(`Failed to restore app ${appUrn} after an update error. Recovery snapshot retained at ${temporaryDirectory}:`, rollbackError);
+        if (temporaryDirectory) {
+          logger.error(
+            `Failed to restore app ${appUrn} after an update error. Recovery snapshot retained at ${temporaryDirectory}. After recovering the app, remove this directory manually:`,
+            rollbackError,
+          );
+        } else {
+          logger.error(`Failed to restore app ${appUrn} after an update error. No recovery snapshot was retained:`, rollbackError);
+        }
       }
 
       const updateError = await this.handleAppError(err, appUrn, 'update_error');
       if (!recoverySucceeded) {
+        if (!temporaryDirectory) {
+          return {
+            success: false,
+            rollbackSucceeded: false,
+            message: `${updateError.message}. Recovery failed before a recovery snapshot could be retained.`,
+          };
+        }
+
+        const cleanupInstruction = 'After recovering the app, remove this directory manually.';
         return {
           success: false,
           rollbackSucceeded: false,
           recoverySnapshotPath: temporaryDirectory,
-          message: `${updateError.message}. Recovery failed; the previous app files are retained at ${temporaryDirectory}.`,
+          message: `${updateError.message}. Recovery failed; the previous app files are retained at ${temporaryDirectory}. ${cleanupInstruction}`,
         };
       }
 

--- a/packages/backend/src/modules/app-lifecycle/handlers/update-app.handler.test.ts
+++ b/packages/backend/src/modules/app-lifecycle/handlers/update-app.handler.test.ts
@@ -13,9 +13,12 @@ import { UpdateConfigHandler } from './update-config.handler';
 
 const appUrn = 'app:test' as AppUrn;
 
+type StoredApp = NonNullable<Awaited<ReturnType<AppsRepository['getAppByUrn']>>>;
+type PublishResult = Awaited<ReturnType<AppEventsQueue['publish']>>;
+
 const waitForQueueResult = async () => new Promise((resolve) => setTimeout(resolve, 0));
 
-test('preserves the previous running status when the update command fails', async () => {
+const createHandler = (options: { initialStatus?: StoredApp['status']; publishResult?: PublishResult } = {}) => {
   const logger = mock<LoggerService>();
   const appRepository = mock<AppsRepository>();
   const appEventsQueue = mock<AppEventsQueue>();
@@ -24,11 +27,15 @@ test('preserves the previous running status when the update command fails', asyn
   const marketplaceService = mock<MarketplaceService>();
   const appFilesManager = mock<AppFilesManager>();
   const updateConfigHandler = mock<UpdateConfigHandler>();
+  const initialStatus = options.initialStatus ?? 'running';
+  const publishResult = options.publishResult ?? { success: true, message: 'updated' };
+  const app = { id: 1, status: initialStatus, config: {}, version: 1 } as StoredApp;
 
-  appRepository.getAppByUrn.mockResolvedValue({ id: 1, status: 'running', config: {} } as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
+  appRepository.getAppByUrn.mockResolvedValue(app);
   config.get.calledWith('version').mockReturnValue('3.0.0' as never);
   marketplaceService.getAppUpdateInfo.mockResolvedValue({ minTipiVersion: null } as Awaited<ReturnType<MarketplaceService['getAppUpdateInfo']>>);
-  appEventsQueue.publish.mockResolvedValue({ success: false, message: 'registry unavailable', rollbackSucceeded: true });
+  appEventsQueue.publish.mockResolvedValue(publishResult);
+  updateConfigHandler.execute.mockResolvedValue({ requestId: 'request-id' });
 
   const handler = new UpdateAppHandler(
     logger,
@@ -40,6 +47,13 @@ test('preserves the previous running status when the update command fails', asyn
     appFilesManager,
     updateConfigHandler,
   );
+
+  return { handler, logger, appRepository, appEventsQueue, statusManager, appFilesManager, updateConfigHandler };
+};
+
+test('preserves the previous running status when the update command fails', async () => {
+  const publishResult = { success: false, message: 'registry unavailable', rollbackSucceeded: true } as const;
+  const { handler, appEventsQueue, appRepository } = createHandler({ publishResult });
 
   await handler.execute(appUrn, { performBackup: true });
   await waitForQueueResult();
@@ -54,30 +68,8 @@ test('preserves the previous running status when the update command fails', asyn
 test.each(['app.env could not be read', 'staging directory could not be created'])(
   'keeps a running app running when update setup fails: %s',
   async (message) => {
-    const logger = mock<LoggerService>();
-    const appRepository = mock<AppsRepository>();
-    const appEventsQueue = mock<AppEventsQueue>();
-    const statusManager = mock<StatusManagerService>();
-    const config = mock<ConfigurationService>();
-    const marketplaceService = mock<MarketplaceService>();
-    const appFilesManager = mock<AppFilesManager>();
-    const updateConfigHandler = mock<UpdateConfigHandler>();
-
-    appRepository.getAppByUrn.mockResolvedValue({ id: 1, status: 'running', config: {} } as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
-    config.get.calledWith('version').mockReturnValue('3.0.0' as never);
-    marketplaceService.getAppUpdateInfo.mockResolvedValue({ minTipiVersion: null } as Awaited<ReturnType<MarketplaceService['getAppUpdateInfo']>>);
-    appEventsQueue.publish.mockResolvedValue({ success: false, message, rollbackSucceeded: true });
-
-    const handler = new UpdateAppHandler(
-      logger,
-      appRepository,
-      appEventsQueue,
-      statusManager,
-      config,
-      marketplaceService,
-      appFilesManager,
-      updateConfigHandler,
-    );
+    const publishResult = { success: false, message, rollbackSucceeded: true } as const;
+    const { handler, appRepository } = createHandler({ publishResult });
 
     await handler.execute(appUrn, { performBackup: true });
     await waitForQueueResult();
@@ -87,35 +79,13 @@ test.each(['app.env could not be read', 'staging directory could not be created'
 );
 
 test('keeps the app stopped when rollback did not restore the previous deployment', async () => {
-  const logger = mock<LoggerService>();
-  const appRepository = mock<AppsRepository>();
-  const appEventsQueue = mock<AppEventsQueue>();
-  const statusManager = mock<StatusManagerService>();
-  const config = mock<ConfigurationService>();
-  const marketplaceService = mock<MarketplaceService>();
-  const appFilesManager = mock<AppFilesManager>();
-  const updateConfigHandler = mock<UpdateConfigHandler>();
-
-  appRepository.getAppByUrn.mockResolvedValue({ id: 1, status: 'running', config: {} } as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
-  config.get.calledWith('version').mockReturnValue('3.0.0' as never);
-  marketplaceService.getAppUpdateInfo.mockResolvedValue({ minTipiVersion: null } as Awaited<ReturnType<MarketplaceService['getAppUpdateInfo']>>);
-  appEventsQueue.publish.mockResolvedValue({
+  const publishResult = {
     success: false,
     message: 'target failed. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
     rollbackSucceeded: false,
     recoverySnapshotPath: '/tmp/runtipi-update-abc',
-  });
-
-  const handler = new UpdateAppHandler(
-    logger,
-    appRepository,
-    appEventsQueue,
-    statusManager,
-    config,
-    marketplaceService,
-    appFilesManager,
-    updateConfigHandler,
-  );
+  } as const;
+  const { handler, statusManager, appRepository } = createHandler({ publishResult });
 
   await handler.execute(appUrn, { performBackup: true });
   await waitForQueueResult();
@@ -126,36 +96,45 @@ test('keeps the app stopped when rollback did not restore the previous deploymen
   expect(appRepository.updateAppById).toHaveBeenLastCalledWith(1, { status: 'stopped' });
 });
 
+test('restores the previous status when publishing the update fails', async () => {
+  const { handler, logger, appRepository, appEventsQueue, statusManager } = createHandler();
+  appEventsQueue.publish.mockRejectedValue(new Error('queue unavailable'));
+
+  await handler.execute(appUrn, { performBackup: true });
+  await waitForQueueResult();
+
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('queue unavailable'));
+  expect(statusManager.emitEvent).toHaveBeenCalledWith(expect.objectContaining({ event: 'update_error', error: 'queue unavailable' }));
+  expect(appRepository.updateAppById).toHaveBeenLastCalledWith(1, { status: 'running' });
+});
+
+test('preserves the rollback status when processing a failed update result rejects', async () => {
+  const publishResult = { success: false, message: 'deployment failed', rollbackSucceeded: false } as const;
+  const { handler, appRepository } = createHandler({ publishResult });
+  appRepository.updateAppById.mockRejectedValueOnce(new Error('database unavailable')).mockResolvedValue({} as StoredApp);
+
+  await handler.execute(appUrn, { performBackup: true });
+  await waitForQueueResult();
+
+  expect(appRepository.updateAppById).toHaveBeenLastCalledWith(1, { status: 'stopped' });
+});
+
 test('starts a successful update without pulling the same images again', async () => {
-  const logger = mock<LoggerService>();
-  const appRepository = mock<AppsRepository>();
-  const appEventsQueue = mock<AppEventsQueue>();
-  const statusManager = mock<StatusManagerService>();
-  const config = mock<ConfigurationService>();
-  const marketplaceService = mock<MarketplaceService>();
-  const appFilesManager = mock<AppFilesManager>();
-  const updateConfigHandler = mock<UpdateConfigHandler>();
-
-  appRepository.getAppByUrn.mockResolvedValue({ id: 1, status: 'running', config: {} } as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
-  config.get.calledWith('version').mockReturnValue('3.0.0' as never);
-  marketplaceService.getAppUpdateInfo.mockResolvedValue({ minTipiVersion: null } as Awaited<ReturnType<MarketplaceService['getAppUpdateInfo']>>);
-  appEventsQueue.publish.mockResolvedValue({ success: true, message: 'updated' });
+  const { handler, statusManager, appFilesManager } = createHandler();
   appFilesManager.getInstalledAppInfo.mockResolvedValue({ tipi_version: 2 } as Awaited<ReturnType<AppFilesManager['getInstalledAppInfo']>>);
-  updateConfigHandler.execute.mockResolvedValue({ requestId: 'request-id' });
-
-  const handler = new UpdateAppHandler(
-    logger,
-    appRepository,
-    appEventsQueue,
-    statusManager,
-    config,
-    marketplaceService,
-    appFilesManager,
-    updateConfigHandler,
-  );
 
   await handler.execute(appUrn, { performBackup: false });
   await waitForQueueResult();
 
   expect(statusManager.emitSuccess).toHaveBeenCalledWith(expect.objectContaining({ appId: 1, appUrn, event: 'update_success', status: 'running' }));
+});
+
+test('preserves the stored version when installed app info is unavailable', async () => {
+  const { handler, appRepository, appFilesManager } = createHandler();
+  appFilesManager.getInstalledAppInfo.mockResolvedValue(null);
+
+  await handler.execute(appUrn, { performBackup: false });
+  await waitForQueueResult();
+
+  expect(appRepository.updateAppById).toHaveBeenCalledWith(1, { version: 1 });
 });

--- a/packages/backend/src/modules/app-lifecycle/handlers/update-app.handler.test.ts
+++ b/packages/backend/src/modules/app-lifecycle/handlers/update-app.handler.test.ts
@@ -1,0 +1,161 @@
+import { ConfigurationService } from '@/core/config/configuration.service';
+import { LoggerService } from '@/core/logger/logger.service';
+import { AppFilesManager } from '@/modules/apps/app-files-manager';
+import { AppsRepository } from '@/modules/apps/apps.repository';
+import { MarketplaceService } from '@/modules/marketplace/marketplace.service';
+import { AppEventsQueue } from '@/modules/queue/entities/app-events';
+import type { AppUrn } from '@runtipi/common/types';
+import { expect, test } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+import { StatusManagerService } from '../services/status-manager.service';
+import { UpdateAppHandler } from './update-app.handler';
+import { UpdateConfigHandler } from './update-config.handler';
+
+const appUrn = 'app:test' as AppUrn;
+
+const waitForQueueResult = async () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test('preserves the previous running status when the update command fails', async () => {
+  const logger = mock<LoggerService>();
+  const appRepository = mock<AppsRepository>();
+  const appEventsQueue = mock<AppEventsQueue>();
+  const statusManager = mock<StatusManagerService>();
+  const config = mock<ConfigurationService>();
+  const marketplaceService = mock<MarketplaceService>();
+  const appFilesManager = mock<AppFilesManager>();
+  const updateConfigHandler = mock<UpdateConfigHandler>();
+
+  appRepository.getAppByUrn.mockResolvedValue({ id: 1, status: 'running', config: {} } as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
+  config.get.calledWith('version').mockReturnValue('3.0.0' as never);
+  marketplaceService.getAppUpdateInfo.mockResolvedValue({ minTipiVersion: null } as Awaited<ReturnType<MarketplaceService['getAppUpdateInfo']>>);
+  appEventsQueue.publish.mockResolvedValue({ success: false, message: 'registry unavailable', rollbackSucceeded: true });
+
+  const handler = new UpdateAppHandler(
+    logger,
+    appRepository,
+    appEventsQueue,
+    statusManager,
+    config,
+    marketplaceService,
+    appFilesManager,
+    updateConfigHandler,
+  );
+
+  await handler.execute(appUrn, { performBackup: true });
+  await waitForQueueResult();
+
+  expect(appEventsQueue.publish).toHaveBeenCalledWith(
+    expect.objectContaining({ command: 'update', appUrn, performBackup: true, wasRunningBeforeUpdate: true }),
+  );
+  expect(appRepository.updateAppById).toHaveBeenLastCalledWith(1, { status: 'running' });
+  expect(appRepository.updateAppById).not.toHaveBeenCalledWith(1, { status: 'stopped' });
+});
+
+test.each(['app.env could not be read', 'staging directory could not be created'])(
+  'keeps a running app running when update setup fails: %s',
+  async (message) => {
+    const logger = mock<LoggerService>();
+    const appRepository = mock<AppsRepository>();
+    const appEventsQueue = mock<AppEventsQueue>();
+    const statusManager = mock<StatusManagerService>();
+    const config = mock<ConfigurationService>();
+    const marketplaceService = mock<MarketplaceService>();
+    const appFilesManager = mock<AppFilesManager>();
+    const updateConfigHandler = mock<UpdateConfigHandler>();
+
+    appRepository.getAppByUrn.mockResolvedValue({ id: 1, status: 'running', config: {} } as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
+    config.get.calledWith('version').mockReturnValue('3.0.0' as never);
+    marketplaceService.getAppUpdateInfo.mockResolvedValue({ minTipiVersion: null } as Awaited<ReturnType<MarketplaceService['getAppUpdateInfo']>>);
+    appEventsQueue.publish.mockResolvedValue({ success: false, message, rollbackSucceeded: true });
+
+    const handler = new UpdateAppHandler(
+      logger,
+      appRepository,
+      appEventsQueue,
+      statusManager,
+      config,
+      marketplaceService,
+      appFilesManager,
+      updateConfigHandler,
+    );
+
+    await handler.execute(appUrn, { performBackup: true });
+    await waitForQueueResult();
+
+    expect(appRepository.updateAppById).toHaveBeenLastCalledWith(1, { status: 'running' });
+  },
+);
+
+test('keeps the app stopped when rollback did not restore the previous deployment', async () => {
+  const logger = mock<LoggerService>();
+  const appRepository = mock<AppsRepository>();
+  const appEventsQueue = mock<AppEventsQueue>();
+  const statusManager = mock<StatusManagerService>();
+  const config = mock<ConfigurationService>();
+  const marketplaceService = mock<MarketplaceService>();
+  const appFilesManager = mock<AppFilesManager>();
+  const updateConfigHandler = mock<UpdateConfigHandler>();
+
+  appRepository.getAppByUrn.mockResolvedValue({ id: 1, status: 'running', config: {} } as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
+  config.get.calledWith('version').mockReturnValue('3.0.0' as never);
+  marketplaceService.getAppUpdateInfo.mockResolvedValue({ minTipiVersion: null } as Awaited<ReturnType<MarketplaceService['getAppUpdateInfo']>>);
+  appEventsQueue.publish.mockResolvedValue({
+    success: false,
+    message: 'target failed. Recovery failed; the previous app files are retained at /tmp/runtipi-update-abc.',
+    rollbackSucceeded: false,
+    recoverySnapshotPath: '/tmp/runtipi-update-abc',
+  });
+
+  const handler = new UpdateAppHandler(
+    logger,
+    appRepository,
+    appEventsQueue,
+    statusManager,
+    config,
+    marketplaceService,
+    appFilesManager,
+    updateConfigHandler,
+  );
+
+  await handler.execute(appUrn, { performBackup: true });
+  await waitForQueueResult();
+
+  expect(statusManager.emitEvent).toHaveBeenCalledWith(
+    expect.objectContaining({ event: 'update_error', error: expect.stringContaining('/tmp/runtipi-update-abc') }),
+  );
+  expect(appRepository.updateAppById).toHaveBeenLastCalledWith(1, { status: 'stopped' });
+});
+
+test('starts a successful update without pulling the same images again', async () => {
+  const logger = mock<LoggerService>();
+  const appRepository = mock<AppsRepository>();
+  const appEventsQueue = mock<AppEventsQueue>();
+  const statusManager = mock<StatusManagerService>();
+  const config = mock<ConfigurationService>();
+  const marketplaceService = mock<MarketplaceService>();
+  const appFilesManager = mock<AppFilesManager>();
+  const updateConfigHandler = mock<UpdateConfigHandler>();
+
+  appRepository.getAppByUrn.mockResolvedValue({ id: 1, status: 'running', config: {} } as Awaited<ReturnType<AppsRepository['getAppByUrn']>>);
+  config.get.calledWith('version').mockReturnValue('3.0.0' as never);
+  marketplaceService.getAppUpdateInfo.mockResolvedValue({ minTipiVersion: null } as Awaited<ReturnType<MarketplaceService['getAppUpdateInfo']>>);
+  appEventsQueue.publish.mockResolvedValue({ success: true, message: 'updated' });
+  appFilesManager.getInstalledAppInfo.mockResolvedValue({ tipi_version: 2 } as Awaited<ReturnType<AppFilesManager['getInstalledAppInfo']>>);
+  updateConfigHandler.execute.mockResolvedValue({ requestId: 'request-id' });
+
+  const handler = new UpdateAppHandler(
+    logger,
+    appRepository,
+    appEventsQueue,
+    statusManager,
+    config,
+    marketplaceService,
+    appFilesManager,
+    updateConfigHandler,
+  );
+
+  await handler.execute(appUrn, { performBackup: false });
+  await waitForQueueResult();
+
+  expect(statusManager.emitSuccess).toHaveBeenCalledWith(expect.objectContaining({ appId: 1, appUrn, event: 'update_success', status: 'running' }));
+});

--- a/packages/backend/src/modules/app-lifecycle/handlers/update-app.handler.ts
+++ b/packages/backend/src/modules/app-lifecycle/handlers/update-app.handler.ts
@@ -9,7 +9,6 @@ import { AppsRepository } from '../../apps/apps.repository';
 import { MarketplaceService } from '../../marketplace/marketplace.service';
 import { AppEventsQueue } from '../../queue/entities/app-events';
 import { StatusManagerService } from '../services/status-manager.service';
-import { StartAppHandler } from './start-app.handler';
 import { UpdateConfigHandler } from './update-config.handler';
 import { type HandlerResult, type ILifecycleHandler, generateRequestId } from './base-handler';
 
@@ -27,7 +26,6 @@ export class UpdateAppHandler implements ILifecycleHandler<UpdateAppParams> {
     private readonly config: ConfigurationService,
     private readonly marketplaceService: MarketplaceService,
     private readonly appFilesManager: AppFilesManager,
-    private readonly startAppHandler: StartAppHandler,
     private readonly updateConfigHandler: UpdateConfigHandler,
   ) {}
 
@@ -51,25 +49,25 @@ export class UpdateAppHandler implements ILifecycleHandler<UpdateAppParams> {
 
     const requestId = generateRequestId();
 
-    this.appEventsQueue.publish({ command: 'update', appUrn, requestId, form: app.config, performBackup }).then(async ({ success, message }) => {
-      if (success) {
-        const appInfo = await this.appFilesManager.getInstalledAppInfo(appUrn);
+    this.appEventsQueue
+      .publish({ command: 'update', appUrn, requestId, form: app.config, performBackup, wasRunningBeforeUpdate: appStatusBeforeUpdate === 'running' })
+      .then(async (result) => {
+        const { success, message } = result;
+        const rollbackSucceeded = 'rollbackSucceeded' in result ? result.rollbackSucceeded : undefined;
 
-        await this.updateConfigHandler.execute(appUrn, { form: app.config });
-        await this.appRepository.updateAppById(app.id, { version: appInfo?.tipi_version });
-        this.statusManager.emitEvent({ appUrn, event: 'update_success' });
+        if (success) {
+          const appInfo = await this.appFilesManager.getInstalledAppInfo(appUrn);
 
-        if (appStatusBeforeUpdate === 'running') {
-          await this.startAppHandler.execute(appUrn);
+          await this.updateConfigHandler.execute(appUrn, { form: app.config });
+          await this.appRepository.updateAppById(app.id, { version: appInfo?.tipi_version });
+          await this.statusManager.emitSuccess({ appId: app.id, appUrn, event: 'update_success', status: appStatusBeforeUpdate });
         } else {
-          await this.appRepository.updateAppById(app.id, { status: appStatusBeforeUpdate });
+          this.logger.error(`Failed to update app ${appUrn}: ${message}`);
+          this.statusManager.emitEvent({ appUrn, event: 'update_error', error: message });
+
+          await this.appRepository.updateAppById(app.id, { status: rollbackSucceeded === true ? appStatusBeforeUpdate : 'stopped' });
         }
-      } else {
-        this.logger.error(`Failed to update app ${appUrn}: ${message}`);
-        this.statusManager.emitEvent({ appUrn, event: 'update_error', error: message });
-        await this.appRepository.updateAppById(app.id, { status: 'stopped' });
-      }
-    });
+      });
 
     return { requestId };
   }

--- a/packages/backend/src/modules/app-lifecycle/handlers/update-app.handler.ts
+++ b/packages/backend/src/modules/app-lifecycle/handlers/update-app.handler.ts
@@ -46,27 +46,38 @@ export class UpdateAppHandler implements ILifecycleHandler<UpdateAppParams> {
 
     await this.statusManager.transitionTo(app.id, appUrn, 'updating');
     const appStatusBeforeUpdate = app.status;
+    const wasRunningBeforeUpdate = appStatusBeforeUpdate === 'running';
 
     const requestId = generateRequestId();
+    const updateEvent = { command: 'update' as const, appUrn, requestId, form: app.config, performBackup, wasRunningBeforeUpdate };
+    let terminalStatus = appStatusBeforeUpdate;
 
     this.appEventsQueue
-      .publish({ command: 'update', appUrn, requestId, form: app.config, performBackup, wasRunningBeforeUpdate: appStatusBeforeUpdate === 'running' })
+      .publish(updateEvent)
       .then(async (result) => {
         const { success, message } = result;
         const rollbackSucceeded = 'rollbackSucceeded' in result ? result.rollbackSucceeded : undefined;
 
         if (success) {
           const appInfo = await this.appFilesManager.getInstalledAppInfo(appUrn);
+          const updatedVersion = appInfo?.tipi_version ?? app.version;
 
           await this.updateConfigHandler.execute(appUrn, { form: app.config });
-          await this.appRepository.updateAppById(app.id, { version: appInfo?.tipi_version });
+          await this.appRepository.updateAppById(app.id, { version: updatedVersion });
           await this.statusManager.emitSuccess({ appId: app.id, appUrn, event: 'update_success', status: appStatusBeforeUpdate });
         } else {
           this.logger.error(`Failed to update app ${appUrn}: ${message}`);
           this.statusManager.emitEvent({ appUrn, event: 'update_error', error: message });
 
-          await this.appRepository.updateAppById(app.id, { status: rollbackSucceeded === true ? appStatusBeforeUpdate : 'stopped' });
+          terminalStatus = rollbackSucceeded === true ? appStatusBeforeUpdate : 'stopped';
+          await this.appRepository.updateAppById(app.id, { status: terminalStatus });
         }
+      })
+      .catch(async (error) => {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        this.logger.error(`Failed to process update result for app ${appUrn}: ${errorMessage}`);
+        this.statusManager.emitEvent({ appUrn, event: 'update_error', error: errorMessage });
+        await this.appRepository.updateAppById(app.id, { status: terminalStatus });
       });
 
     return { requestId };

--- a/packages/backend/src/modules/app-stores/__tests__/app-store-files-manager.security.test.ts
+++ b/packages/backend/src/modules/app-stores/__tests__/app-store-files-manager.security.test.ts
@@ -32,11 +32,13 @@ const validAppConfig = {
 
 describe('AppStoreFilesManager file security', () => {
   let manager: AppStoreFilesManager;
+  let filesystem: FilesystemService;
 
   beforeEach(async () => {
     const logger = {
       debug: vi.fn(),
       error: vi.fn(),
+      info: vi.fn(),
       warn: vi.fn(),
     } as unknown as LoggerService;
 
@@ -45,7 +47,8 @@ describe('AppStoreFilesManager file security', () => {
       getConfig: vi.fn().mockReturnValue({ directories }),
     } as unknown as ConfigurationService;
 
-    manager = new AppStoreFilesManager(configuration, new FilesystemService(logger), logger, { slug: 'evil' } as AppStore);
+    filesystem = new FilesystemService(logger);
+    manager = new AppStoreFilesManager(configuration, filesystem, logger, { slug: 'evil' } as AppStore);
 
     await writeFile(path.join(APP_DIR, 'assets', 'default-app-logo.jpg'), 'default-logo');
   });
@@ -108,5 +111,45 @@ describe('AppStoreFilesManager file security', () => {
     const { content } = await manager.getSourceDockerComposeYaml('demo:evil' as AppUrn);
 
     expect(JSON.stringify(content)).not.toContain('leak');
+  });
+
+  it('fails when removing the existing installed app files fails', async () => {
+    vi.spyOn(filesystem, 'isDirectory').mockResolvedValue(true);
+    vi.spyOn(filesystem, 'removeDirectory').mockResolvedValue(false);
+    const createDirectory = vi.spyOn(filesystem, 'createDirectory');
+
+    await expect(manager.copyAppFromRepoToInstalled('demo:evil' as AppUrn)).rejects.toThrow('Failed to remove installed files for app demo:evil');
+    expect(createDirectory).not.toHaveBeenCalled();
+  });
+
+  it('fails when creating the installed app directory fails', async () => {
+    vi.spyOn(filesystem, 'isDirectory').mockResolvedValue(true);
+    vi.spyOn(filesystem, 'removeDirectory').mockResolvedValue(true);
+    vi.spyOn(filesystem, 'createDirectory').mockResolvedValue(false);
+    const copyDirectory = vi.spyOn(filesystem, 'copyDirectory');
+
+    await expect(manager.copyAppFromRepoToInstalled('demo:evil' as AppUrn)).rejects.toThrow(
+      'Failed to create installed files directory for app demo:evil',
+    );
+    expect(copyDirectory).not.toHaveBeenCalled();
+  });
+
+  it('fails when creating the app data directory fails', async () => {
+    vi.spyOn(filesystem, 'isDirectory').mockResolvedValue(true);
+    vi.spyOn(filesystem, 'removeDirectory').mockResolvedValue(true);
+    vi.spyOn(filesystem, 'createDirectory').mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const copyDirectory = vi.spyOn(filesystem, 'copyDirectory');
+
+    await expect(manager.copyAppFromRepoToInstalled('demo:evil' as AppUrn)).rejects.toThrow('Failed to create data directory for app demo:evil');
+    expect(copyDirectory).not.toHaveBeenCalled();
+  });
+
+  it('fails when copying the repository app files fails', async () => {
+    vi.spyOn(filesystem, 'isDirectory').mockResolvedValue(true);
+    vi.spyOn(filesystem, 'removeDirectory').mockResolvedValue(true);
+    vi.spyOn(filesystem, 'createDirectory').mockResolvedValue(true);
+    vi.spyOn(filesystem, 'copyDirectory').mockResolvedValue(false);
+
+    await expect(manager.copyAppFromRepoToInstalled('demo:evil' as AppUrn)).rejects.toThrow('Failed to copy app demo:evil from repo evil');
   });
 });

--- a/packages/backend/src/modules/app-stores/app-store-files-manager.ts
+++ b/packages/backend/src/modules/app-stores/app-store-files-manager.ts
@@ -147,19 +147,27 @@ export class AppStoreFilesManager {
 
     // delete eventual app folder if exists
     this.logger.info(`Deleting app ${appUrn} folder if exists`);
-    await this.filesystem.removeDirectory(appInstalledDir);
+    if (!(await this.filesystem.removeDirectory(appInstalledDir))) {
+      throw new Error(`Failed to remove installed files for app ${appUrn}`);
+    }
 
     // Create app folder
     this.logger.info(`Creating app ${appUrn} folder`);
-    await this.filesystem.createDirectory(appInstalledDir);
+    if (!(await this.filesystem.createDirectory(appInstalledDir))) {
+      throw new Error(`Failed to create installed files directory for app ${appUrn}`);
+    }
 
     // Create app data folder
     this.logger.info(`Creating app ${appUrn} data folder`);
-    await this.filesystem.createDirectory(appDataDir);
+    if (!(await this.filesystem.createDirectory(appDataDir))) {
+      throw new Error(`Failed to create data directory for app ${appUrn}`);
+    }
 
     // Copy app folder from repo
     this.logger.info(`Copying app ${appUrn} from repo ${this.storeConfig.slug}`);
-    await this.filesystem.copyDirectory(appRepoDir, appInstalledDir);
+    if (!(await this.filesystem.copyDirectory(appRepoDir, appInstalledDir))) {
+      throw new Error(`Failed to copy app ${appUrn} from repo ${this.storeConfig.slug}`);
+    }
   }
 
   /**

--- a/packages/backend/src/modules/apps/__tests__/app-files-manager.security.test.ts
+++ b/packages/backend/src/modules/apps/__tests__/app-files-manager.security.test.ts
@@ -31,6 +31,7 @@ const writeFile = async (filePath: string, content: string) => {
 
 describe('AppFilesManager file security', () => {
   let manager: AppFilesManager;
+  let filesystem: FilesystemService;
 
   beforeEach(() => {
     const logger = {
@@ -43,7 +44,8 @@ describe('AppFilesManager file security', () => {
       getConfig: vi.fn().mockReturnValue({ directories }),
     } as unknown as ConfigurationService;
 
-    manager = new AppFilesManager(configuration, new FilesystemService(logger), logger);
+    filesystem = new FilesystemService(logger);
+    manager = new AppFilesManager(configuration, filesystem, logger);
   });
 
   it('does not expose installed app description symlink targets', async () => {
@@ -65,7 +67,32 @@ describe('AppFilesManager file security', () => {
 
     const appEnv = await manager.getAppEnv('demo:evil' as AppUrn);
 
-    expect(appEnv.content).toBe('');
+    expect(appEnv.content).toBeNull();
+  });
+
+  it('exposes a failed installed app folder deletion', async () => {
+    vi.spyOn(filesystem, 'removeDirectory').mockResolvedValue(false);
+
+    await expect(manager.deleteAppFolder('demo:evil' as AppUrn)).resolves.toBe(false);
+  });
+
+  it('fails when writing the generated compose file fails', async () => {
+    vi.spyOn(filesystem, 'writeTextFile').mockResolvedValue(false);
+
+    await expect(manager.writeDockerComposeYml('demo:evil' as AppUrn, 'services: {}')).rejects.toThrow(
+      'Failed to write generated docker compose file for app demo:evil',
+    );
+  });
+
+  it('writes recovery snapshots with owner-only permissions', async () => {
+    const snapshotPath = path.join(DATA_DIR, 'private-recovery-snapshot');
+
+    try {
+      expect(await filesystem.writePrivateTextFile(snapshotPath, 'secret')).toBe(true);
+      expect((await fs.promises.stat(snapshotPath)).mode & 0o777).toBe(0o600);
+    } finally {
+      await fs.promises.rm(snapshotPath, { force: true });
+    }
   });
 
   it('does not read user config symlink targets', async () => {

--- a/packages/backend/src/modules/apps/__tests__/app.helpers.test.ts
+++ b/packages/backend/src/modules/apps/__tests__/app.helpers.test.ts
@@ -78,6 +78,7 @@ describe('AppHelpers', () => {
       envUtils.envMapToString.mockReturnValue('');
       appFilesManager.getInstalledAppInfo.mockResolvedValue(mockAppInfo);
       appFilesManager.getAppEnv.mockResolvedValue({ path: '/data/.env', content: '' });
+      appFilesManager.writeAppEnv.mockResolvedValue(true);
       filesystem.readTextFile.mockResolvedValue('');
     });
 
@@ -279,6 +280,12 @@ describe('AppHelpers', () => {
 
       // Assert
       expect(appFilesManager.writeAppEnv).toHaveBeenCalledWith(testAppUrn, transformedEnv);
+    });
+
+    it('should throw if writing the environment file fails', async () => {
+      appFilesManager.writeAppEnv.mockResolvedValue(false);
+
+      await expect(appHelpers.generateEnvFile(testAppUrn, {})).rejects.toThrow(`Failed to write app environment for ${testAppUrn}`);
     });
 
     it('should use default value when form field is not provided', async () => {

--- a/packages/backend/src/modules/apps/app-files-manager.ts
+++ b/packages/backend/src/modules/apps/app-files-manager.ts
@@ -162,7 +162,7 @@ export class AppFilesManager {
    * @param appUrn - The app id
    * @param composeFile - The content of the docker-compose.yml file
    */
-  public async writeDockerComposeYml(appUrn: AppUrn, composeFile: string): Promise<void> {
+  public async writeDockerComposeYml(appUrn: AppUrn, composeFile: string) {
     const { appInstalledDir } = this.getAppPaths(appUrn);
     const dockerComposePath = path.join(appInstalledDir, APP_GENERATED_COMPOSE_FILENAME);
 
@@ -214,7 +214,7 @@ export class AppFilesManager {
     return { path: envPath, content: env };
   }
 
-  public async writeAppEnv(appUrn: AppUrn, env: string): Promise<boolean> {
+  public async writeAppEnv(appUrn: AppUrn, env: string) {
     const { appDataDir } = this.getAppPaths(appUrn);
 
     const envPath = path.join(appDataDir, 'app.env');

--- a/packages/backend/src/modules/apps/app-files-manager.ts
+++ b/packages/backend/src/modules/apps/app-files-manager.ts
@@ -162,16 +162,18 @@ export class AppFilesManager {
    * @param appUrn - The app id
    * @param composeFile - The content of the docker-compose.yml file
    */
-  public async writeDockerComposeYml(appUrn: AppUrn, composeFile: string) {
+  public async writeDockerComposeYml(appUrn: AppUrn, composeFile: string): Promise<void> {
     const { appInstalledDir } = this.getAppPaths(appUrn);
     const dockerComposePath = path.join(appInstalledDir, APP_GENERATED_COMPOSE_FILENAME);
 
-    await this.filesystem.writeTextFile(dockerComposePath, composeFile);
+    if (!(await this.filesystem.writeTextFile(dockerComposePath, composeFile))) {
+      throw new Error(`Failed to write generated docker compose file for app ${appUrn}`);
+    }
   }
 
   public async deleteAppFolder(appUrn: AppUrn) {
     const { appInstalledDir } = this.getAppPaths(appUrn);
-    await this.filesystem.removeDirectory(appInstalledDir);
+    return this.filesystem.removeDirectory(appInstalledDir);
   }
 
   public async deleteAppDataDir(appUrn: AppUrn) {
@@ -201,20 +203,23 @@ export class AppFilesManager {
 
     const envPath = path.join(appDataDir, 'app.env');
 
-    let env = '';
+    let env: string | null = null;
     if (await this.filesystem.isFile(envPath)) {
-      env = (await this.filesystem.readTextFile(envPath)) ?? '';
+      env = await this.filesystem.readTextFile(envPath);
+      if (env === null) {
+        throw new Error(`Failed to read app environment for ${appUrn}`);
+      }
     }
 
     return { path: envPath, content: env };
   }
 
-  public async writeAppEnv(appUrn: AppUrn, env: string) {
+  public async writeAppEnv(appUrn: AppUrn, env: string): Promise<boolean> {
     const { appDataDir } = this.getAppPaths(appUrn);
 
     const envPath = path.join(appDataDir, 'app.env');
 
-    await this.filesystem.writeTextFile(envPath, env);
+    return this.filesystem.writeTextFile(envPath, env);
   }
 
   /**

--- a/packages/backend/src/modules/apps/app.helpers.ts
+++ b/packages/backend/src/modules/apps/app.helpers.ts
@@ -56,7 +56,7 @@ export class AppHelpers {
     envMap.set('APP_IMAGE_TAG', config.version);
 
     const appEnv = await this.appFilesManager.getAppEnv(appUrn);
-    const existingAppEnvMap = this.envUtils.envStringToMap(appEnv.content);
+    const existingAppEnvMap = this.envUtils.envStringToMap(appEnv.content ?? '');
 
     if (config.generate_vapid_keys) {
       if (existingAppEnvMap.has('VAPID_PUBLIC_KEY') && existingAppEnvMap.has('VAPID_PRIVATE_KEY')) {
@@ -129,6 +129,8 @@ export class AppHelpers {
       envMap.set('APP_PROTOCOL', 'https');
     }
 
-    await this.appFilesManager.writeAppEnv(appUrn, this.envUtils.envMapToString(envMap));
+    if (!(await this.appFilesManager.writeAppEnv(appUrn, this.envUtils.envMapToString(envMap)))) {
+      throw new Error(`Failed to write app environment for ${appUrn}`);
+    }
   };
 }

--- a/packages/backend/src/modules/network/__tests__/subnet-manager.service.test.ts
+++ b/packages/backend/src/modules/network/__tests__/subnet-manager.service.test.ts
@@ -67,6 +67,20 @@ describe('SubnetManagerService', () => {
       expect(appsRepository.updateAppById).toHaveBeenCalledWith(1, { subnet: newSubnet });
     });
 
+    it('should allocate a subnet without persisting it when persistence is disabled', async () => {
+      // arrange
+      const appUrn = 'app:test/app' as AppUrn;
+      const newSubnet = '10.128.10.0/24';
+      appsRepository.getAppByUrn.mockResolvedValue(fromPartial({ id: 1, subnet: null }));
+
+      // act
+      const result = await service.allocateSubnet(appUrn, { persist: false });
+
+      // assert
+      expect(result).toBe(newSubnet);
+      expect(appsRepository.updateAppById).not.toHaveBeenCalled();
+    });
+
     it('should reuse an existing subnet without writing it again', async () => {
       // arrange
       const appUrn = 'app:test/app' as AppUrn;

--- a/packages/backend/src/modules/network/__tests__/subnet-manager.service.test.ts
+++ b/packages/backend/src/modules/network/__tests__/subnet-manager.service.test.ts
@@ -67,6 +67,21 @@ describe('SubnetManagerService', () => {
       expect(appsRepository.updateAppById).toHaveBeenCalledWith(1, { subnet: newSubnet });
     });
 
+    it('should reuse an existing subnet without writing it again', async () => {
+      // arrange
+      const appUrn = 'app:test/app' as AppUrn;
+      const existingSubnet = '10.128.10.0/24';
+      appsRepository.getAppByUrn.mockResolvedValue(fromPartial({ id: 1, subnet: existingSubnet }));
+
+      // act
+      const result = await service.allocateSubnet(appUrn);
+
+      // assert
+      expect(result).toBe(existingSubnet);
+      expect(appsRepository.updateAppById).not.toHaveBeenCalled();
+      expect(dockerMock.listNetworks).not.toHaveBeenCalled();
+    });
+
     it('should skip already allocated subnets when allocating a new one', async () => {
       // arrange
       const appUrn = 'app:test/app' as AppUrn;

--- a/packages/backend/src/modules/network/subnet-manager.service.ts
+++ b/packages/backend/src/modules/network/subnet-manager.service.ts
@@ -12,6 +12,10 @@ const STARTING_OCTET_2 = 128;
 const MAX_OCTET_VALUE = 254;
 const RESERVED_SUBNET_MAX_OCTET_3 = 9;
 
+type AllocateSubnetOptions = {
+  persist?: boolean;
+};
+
 @Injectable()
 export class SubnetManagerService {
   constructor(
@@ -25,11 +29,15 @@ export class SubnetManagerService {
    * @param appUrn The URN of the app to allocate a subnet for
    * @returns The allocated subnet with mask (e.g., 10.128.10.0/24)
    */
-  public async allocateSubnet(appUrn: AppUrn, retryCount = 0): Promise<string> {
+  public async allocateSubnet(appUrn: AppUrn, options: AllocateSubnetOptions = {}, retryCount = 0): Promise<string> {
     const existingApp = await this.appsRepository.getAppByUrn(appUrn);
 
     if (!existingApp) {
       throw new TranslatableError('APP_ERROR_APP_NOT_FOUND');
+    }
+
+    if (existingApp.subnet) {
+      return existingApp.subnet;
     }
 
     const allocatedSubnets = await this.getAllocatedSubnets();
@@ -39,12 +47,16 @@ export class SubnetManagerService {
       throw new TranslatableError('NETWORK_ERROR_NO_AVAILABLE_SUBNETS');
     }
 
+    if (options.persist === false) {
+      return nextSubnet;
+    }
+
     try {
       await this.appsRepository.updateAppById(existingApp.id, { subnet: nextSubnet });
     } catch (error) {
       if (error instanceof Error && retryCount < MAX_RETRIES) {
         this.logger.error(`Subnet ${nextSubnet} failed to be allocated, retrying...`);
-        return this.allocateSubnet(appUrn, retryCount + 1);
+        return this.allocateSubnet(appUrn, options, retryCount + 1);
       }
       throw error;
     }

--- a/packages/backend/src/modules/queue/entities/app-events.ts
+++ b/packages/backend/src/modules/queue/entities/app-events.ts
@@ -40,6 +40,7 @@ const updateAppCommandSchema = type({
   appUrn: arkAppUrn,
   form: queueAppFormSchema,
   performBackup: type('boolean').default(true),
+  wasRunningBeforeUpdate: type('boolean').default(false),
   requestId: 'string.uuid',
 });
 
@@ -49,6 +50,8 @@ export type AppEvent = typeof appEventSchema.infer;
 export const appEventResultSchema = type({
   success: 'boolean',
   message: 'string',
+  rollbackSucceeded: type('boolean | undefined').optional(),
+  recoverySnapshotPath: type('string | undefined').optional(),
 });
 
 export type AppEventFormInput = typeof queueAppFormSchema.inferIn;

--- a/packages/backend/src/tests/integration/app-lifecycle.test.ts
+++ b/packages/backend/src/tests/integration/app-lifecycle.test.ts
@@ -181,7 +181,13 @@ describe('App lifecycle', () => {
     });
     archiveService.extractTarGz.mockResolvedValue({ stdout: '', stderr: '' });
     vi.spyOn(filesystemService, 'createTempDirectory').mockImplementation(async (prefix) => {
-      const tempDir = path.join('/tmp', `${prefix}-${Date.now()}`);
+      const timestampedPrefix = `${prefix}-${Date.now()}`;
+      let tempDir = timestampedPrefix;
+
+      if (!path.isAbsolute(prefix)) {
+        tempDir = path.join('/tmp', timestampedPrefix);
+      }
+
       await fs.promises.mkdir(tempDir, { recursive: true });
       return tempDir;
     });


### PR DESCRIPTION
Make app updates transactional so a pull or deployment failure does not destroy the previously working installation.

issue #2622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updates now preserve the app’s previous running state.
  - Failed updates attempt automatic rollback of files, configuration, networking, and containers.
  - Recovery details are reported when rollback cannot complete.
  - Existing network assignments are reused when possible.

- **Bug Fixes**
  - File and directory operation failures now surface clear errors instead of continuing silently.
  - Environment and configuration write failures are handled reliably.
  - Recovery snapshots use owner-only permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->