### PR TITLE
Fix/logs terminal mobile overflow

### DIFF
--- a/packages/frontend/src/components/logs-terminal/logs-terminal.tsx
+++ b/packages/frontend/src/components/logs-terminal/logs-terminal.tsx
@@ -28,7 +28,7 @@ export const LogsTerminal = (props: Props) => {
     }
   }, [lastLogId, follow]);
 
-  const updateMaxLines = (lines: number) => {
+    const updateMaxLines = (lines: number) => {
     const linesToKeep = Math.max(1, lines);
     onMaxLinesChange(linesToKeep);
   };
@@ -36,19 +36,19 @@ export const LogsTerminal = (props: Props) => {
   return (
     <div>
       <div className="row d-flex flex-wrap align-items-center ps-1 gy-2">
-        <div className="col-12 col-md-auto">
-          <label className="form-check form-switch" htmlFor="follow-logs">
+        <div className="col-6 col-md-auto">
+          <label className="form-check form-switch mb-0" htmlFor="follow-logs">
             <input id="follow-logs" className="form-check-input" type="checkbox" checked={follow} onChange={() => setFollow(!follow)} />
             <span className="form-check-label">{t('APP_LOGS_TAB_FOLLOW')}</span>
           </label>
         </div>
-        <div className="col-12 col-md-auto">
-          <label className="form-check form-switch" htmlFor="wrap-lines">
+        <div className="col-6 col-md-auto">
+          <label className="form-check form-switch mb-0" htmlFor="wrap-lines">
             <input id="wrap-lines" className="form-check-input" type="checkbox" checked={wrapLines} onChange={() => setWrapLines(!wrapLines)} />
             <span className="form-check-label">{t('APP_LOGS_TAB_WRAP_LINES')}</span>
           </label>
         </div>
-        <div className="col-12 col-md-auto">
+        <div className="col-12 col-md-auto ms-md-auto">
           <div className="input-group">
             <span className="input-group-text">{t('APP_LOGS_TAB_MAX_LINES')}</span>
             <input

--- a/packages/frontend/src/components/logs-terminal/logs-terminal.tsx
+++ b/packages/frontend/src/components/logs-terminal/logs-terminal.tsx
@@ -19,7 +19,7 @@ export const LogsTerminal = (props: Props) => {
   const [wrapLines, setWrapLines] = useLocalStorage<boolean>('logs-wraplines', false);
   const ref = useRef<HTMLPreElement>(null);
 
-  const lastLogId = logs.length > 0 ? logs.at(-1)?.id : null;
+  const lastLogId = logs.at(-1)?.id;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: necessary to update the scroll when a new log is added
   useEffect(() => {
@@ -35,28 +35,28 @@ export const LogsTerminal = (props: Props) => {
 
   return (
     <div>
-      <div className="row d-flex align-items-center ps-1">
-        <div className="col">
-          <label className="form-check form-switch mt-1" htmlFor="follow-logs">
+      <div className="row d-flex flex-wrap align-items-center ps-1 gy-2">
+        <div className="col-12 col-md-auto">
+          <label className="form-check form-switch" htmlFor="follow-logs">
             <input id="follow-logs" className="form-check-input" type="checkbox" checked={follow} onChange={() => setFollow(!follow)} />
             <span className="form-check-label">{t('APP_LOGS_TAB_FOLLOW')}</span>
           </label>
         </div>
-        <div className="col">
-          <label className="form-check form-switch mt-1" htmlFor="follow-logs">
-            <input id="follow-logs" className="form-check-input" type="checkbox" checked={wrapLines} onChange={() => setWrapLines(!wrapLines)} />
+        <div className="col-12 col-md-auto">
+          <label className="form-check form-switch" htmlFor="wrap-lines">
+            <input id="wrap-lines" className="form-check-input" type="checkbox" checked={wrapLines} onChange={() => setWrapLines(!wrapLines)} />
             <span className="form-check-label">{t('APP_LOGS_TAB_WRAP_LINES')}</span>
           </label>
         </div>
-        <div className="col">
-          <div className="input-group mb-2">
+        <div className="col-12 col-md-auto">
+          <div className="input-group">
             <span className="input-group-text">{t('APP_LOGS_TAB_MAX_LINES')}</span>
             <input
-              id="max-lines"
               type="number"
               className="form-control"
-              value={maxLines}
-              onChange={(e) => updateMaxLines(Number.parseInt(e.target.value, 10))}
+              defaultValue={maxLines}
+              min={1}
+              onChange={(e) => updateMaxLines(Number(e.target.value))}
             />
           </div>
         </div>

--- a/packages/frontend/src/components/logs-terminal/logs-terminal.tsx
+++ b/packages/frontend/src/components/logs-terminal/logs-terminal.tsx
@@ -28,8 +28,8 @@ export const LogsTerminal = (props: Props) => {
     }
   }, [lastLogId, follow]);
 
-    const updateMaxLines = (lines: number) => {
-    const linesToKeep = Math.max(1, lines);
+  const updateMaxLines = (lines: number) => {
+    const linesToKeep = Number.isFinite(lines) ? Math.max(1, Math.trunc(lines)) : 1;
     onMaxLinesChange(linesToKeep);
   };
 
@@ -50,12 +50,17 @@ export const LogsTerminal = (props: Props) => {
         </div>
         <div className="col-12 col-md-auto ms-md-auto">
           <div className="input-group">
-            <span className="input-group-text">{t('APP_LOGS_TAB_MAX_LINES')}</span>
+            <label htmlFor="max-lines" className="input-group-text mb-0">
+              {t('APP_LOGS_TAB_MAX_LINES')}
+            </label>
             <input
+              id="max-lines"
               type="number"
               className="form-control"
-              defaultValue={maxLines}
+              aria-label={t('APP_LOGS_TAB_MAX_LINES')}
+              value={maxLines}
               min={1}
+              step={1}
               onChange={(e) => updateMaxLines(Number(e.target.value))}
             />
           </div>


### PR DESCRIPTION
This pull request updates the layout and some behaviors in the `LogsTerminal` component to improve usability and responsiveness, especially for the controls that manage log display options. The main changes involve restructuring the control row for better alignment and mobile support, updating input handling for the max lines field, and minor code cleanups.

**UI and Layout Improvements:**
- The control row now uses `flex-wrap` and responsive Bootstrap column classes (`col-6`, `col-md-auto`, etc.) to ensure that controls wrap and align better on smaller screens. The `gy-2` class adds vertical spacing between rows for improved readability.
- The "Follow logs" and "Wrap lines" switches now use `mb-0` for more consistent vertical alignment, and the "Wrap lines" input is correctly labeled and associated with its own `id`.
- The max lines input is now placed in a `col-12 col-md-auto ms-md-auto` container, ensuring it aligns to the right on larger screens and stacks below on mobile. The input now uses `defaultValue` instead of `value` for better uncontrolled input handling, includes a `min={1}` constraint, and removes the unused `id`.

**Code Quality and Behavior:**
- Simplified the calculation of `lastLogId` by removing an unnecessary ternary; it now safely uses optional chaining.
- The max lines input now parses the value using `Number(e.target.value)` instead of `Number.parseInt`, which is more robust for number input fields.

Tested and validated in local dev environment (`bun run start:dev`):

- [x] **Mobile view (< 768px):** Switches (*Follow logs* & *Wrap lines*) are displayed side-by-side (`col-6`) without overflowing, and the *Max lines* input is placed on its own row below (`col-12`).
- [x] **Desktop view (≥ 768px):** Controls remain aligned on a single row, with the *Max lines* input aligned to the right (`ms-md-auto`), preserving the original desktop layout.
- [x] Tested with multiple installed apps logs and global system logs.

**After**

<img width="462" height="720" alt="Capture d&#39;écran 2026-08-27 001502" src="https://github.com/user-attachments/assets/e1e4bf2b-e509-4bc1-9e59-624da2c278f0" />
<img width="1372" height="627" alt="Capture d&#39;écran 2026-08-27 001725" src="https://github.com/user-attachments/assets/cc53a3d2-34c1-4a3d-8a0c-14219de47c4e" />

**Before** 

<img width="508" height="481" alt="Capture d&#39;écran 2026-08-27 001939" src="https://github.com/user-attachments/assets/c8ab7dd4-9b6c-4d05-bbcd-9b986177a989" />
<img width="1296" height="402" alt="Capture d&#39;écran 2026-08-27 002813" src="https://github.com/user-attachments/assets/5ba37fa8-2b4b-45c6-86ee-f66e96e83762" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log display behavior when no logs are available.
  * Max-lines settings now consistently use valid whole-number values with a minimum of one line.
  * Updated the max-lines control for more reliable input and clearer labeling.
  * Refined the logs toolbar layout and control identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->