### PR TITLE
fix(logs-terminal): align toolbar controls with terminal

### DIFF
--- a/packages/frontend/src/components/logs-terminal/logs-terminal.tsx
+++ b/packages/frontend/src/components/logs-terminal/logs-terminal.tsx
@@ -35,7 +35,7 @@ export const LogsTerminal = (props: Props) => {
 
   return (
     <div>
-      <div className="row d-flex flex-wrap align-items-center ps-1 gy-2">
+      <div className="row d-flex flex-wrap align-items-center gy-2">
         <div className="col-6 col-md-auto">
           <label className="form-check form-switch mb-0" htmlFor="follow-logs">
             <input id="follow-logs" className="form-check-input" type="checkbox" checked={follow} onChange={() => setFollow(!follow)} />


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `LogsTerminal` component. The change removes the unnecessary `ps-1` (padding start) class from the container div, resulting in a slightly different horizontal alignment for the content.

* UI adjustment:
  * [`logs-terminal.tsx`](diffhunk://#diff-0cfe5275fb199b98a639e313e2cd90d8aee4211937335386a3a2ba0335d7f31fL38-R38): Removed the `ps-1` class from the main row div to update the horizontal padding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in the logs control row for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->